### PR TITLE
Update Get-YubiKeyFIDO2 to be more friendly

### DIFF
--- a/Module/Cmdlets/Fido/GetYubikeyFIDO2.cs
+++ b/Module/Cmdlets/Fido/GetYubikeyFIDO2.cs
@@ -35,7 +35,7 @@ namespace powershellYK.Cmdlets.Fido
                 fido2Session.KeyCollector = YubiKeyModule._KeyCollector.YKKeyCollectorDelegate;
 
                 AuthenticatorInfo info = fido2Session.AuthenticatorInfo;
-                WriteObject(info);
+                WriteObject(new Information(info));
 
             }
         }

--- a/Module/support/HexConverter.cs
+++ b/Module/support/HexConverter.cs
@@ -40,5 +40,19 @@ namespace powershellYK.support
                 // If there's an odd number of bytes, the last byte remains unchanged
             }
         }
+
+        public static Version IntToVersion(int version)
+        {
+            byte[] versionBytes = new byte[] { (byte)(version >> 16), (byte)(version >> 8), (byte)version };
+            return ByteArrayToVersion(versionBytes);
+        }
+        public static Version ByteArrayToVersion(byte[] bytes)
+        {
+            if (bytes.Length != 3)
+            {
+                throw new ArgumentException("Version must be 3 bytes long");
+            }
+            return new Version(bytes[0], bytes[1], bytes[2]);
+        }
     }
 }

--- a/Module/types/FIDO2-Info.cs
+++ b/Module/types/FIDO2-Info.cs
@@ -1,0 +1,63 @@
+﻿using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Yubico.YubiKey.Piv;
+using System.Management.Automation;
+using Yubico.YubiKey.Fido2;
+using Yubico.YubiKey.Fido2.PinProtocols;
+using Yubico.YubiKey.Fido2.Cose;
+using powershellYK.support;
+
+namespace powershellYK.FIDO2
+{
+    public class Information
+    {
+        [Hidden]
+        public AuthenticatorInfo AuthenticatorInfo { get; }
+        public Guid? AAGuid { get
+            {
+                if (AuthenticatorInfo.Aaguid.Length != 16)
+                {
+                    return null;
+                }
+                byte[] tempArray = AuthenticatorInfo.Aaguid.ToArray();
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(tempArray, 0, 4);
+                    Array.Reverse(tempArray, 4, 2);
+                    Array.Reverse(tempArray, 6, 2);
+                }
+                return new Guid(tempArray);
+            }
+        }
+        public IReadOnlyList<string> Versions { get { return AuthenticatorInfo.Versions; } }
+        public IReadOnlyList<string>? Extensions { get { return AuthenticatorInfo.Extensions; } }
+        public IReadOnlyDictionary<string, bool>? Options { get { return AuthenticatorInfo.Options; } }
+        public int? MaximumMessageSize { get { return AuthenticatorInfo.MaximumMessageSize; } }
+        public IReadOnlyList<PinUvAuthProtocol>? PinUvAuthProtocols { get { return AuthenticatorInfo.PinUvAuthProtocols; } }
+        public int? MaximumCredentialCountInList { get { return AuthenticatorInfo.MaximumCredentialCountInList; } }
+        public int? MaximumCredentialIdLength { get { return AuthenticatorInfo.MaximumCredentialIdLength; } }
+        public IReadOnlyList<string>? Transports { get { return AuthenticatorInfo.Transports; } }
+        public IReadOnlyList<Tuple<string, CoseAlgorithmIdentifier>>? Algorithms { get { return AuthenticatorInfo.Algorithms; } }
+        public int? MaximumSerializedLargeBlobArray { get { return AuthenticatorInfo.MaximumSerializedLargeBlobArray; } }
+        public bool? ForcePinChange { get { return AuthenticatorInfo.ForcePinChange; } }
+        public int? MinimumPinLength { get { return AuthenticatorInfo.MinimumPinLength; } }
+        public Version? FirmwareVersion;
+        public int? MaximumCredentialBlobLength { get { return AuthenticatorInfo.MaximumCredentialBlobLength; } }
+        public int? MaximumRpidsForSetMinPinLength { get { return AuthenticatorInfo.MaximumRpidsForSetMinPinLength; } }
+        public int? PreferredPlatformUvAttempts { get { return AuthenticatorInfo.PreferredPlatformUvAttempts; } }
+        public int? UvModality { get { return AuthenticatorInfo.UvModality; } }
+        public IReadOnlyDictionary<string, int>? Certifications { get { return AuthenticatorInfo.Certifications; } }
+        public int? RemainingDiscoverableCredentials { get { return AuthenticatorInfo.RemainingDiscoverableCredentials; } }
+        public IReadOnlyList<long>? VendorPrototypeConfigCommands { get { return AuthenticatorInfo.VendorPrototypeConfigCommands; } }
+
+        public Information(AuthenticatorInfo authenticatorInfo)
+        {
+            this.AuthenticatorInfo = authenticatorInfo;
+            if (authenticatorInfo.FirmwareVersion is not null)
+            {
+                this.FirmwareVersion = HexConverter.IntToVersion((int)authenticatorInfo.FirmwareVersion);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
New returned class contains the same info as before. But the FirmwareVersion and AAGUID are fixed.
Original data is available under: 

$a.AuthenticatorInfo

Versions                         : {U2F_V2, FIDO_2_0, FIDO_2_1_PRE, FIDO_2_1}
Extensions                       : {credProtect, hmac-secret, largeBlobKey, credBlob…}
Aaguid                           : System.ReadOnlyMemory<Byte>[16]
FirmwareVersion                  : 329473

The Firmware is the internal structure