### PR TITLE
PIV Attestation updates

### DIFF
--- a/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
+++ b/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
@@ -57,21 +57,31 @@ namespace powershellYK.Cmdlets.PIV
                 CertificateRequest request;
                 X509SignatureGenerator signer;
 
-
+                // get the metadata catch if fails                
+                PivMetadata? metadata = null;
                 PivPublicKey? publicKey = null;
                 try
                 {
-                    publicKey = pivSession.GetMetadata(Slot).PublicKey;
-                    if (publicKey is null)
-                    {
-                        throw new Exception("Public key is null");
-                    }
+                    metadata = pivSession.GetMetadata(Slot);
+                    publicKey = metadata.PublicKey;
+
                 }
                 catch (Exception e)
                 {
-                    throw new Exception($"Failed to get public key for slot {Slot}, does there exist a key?", e);
+                    throw new Exception($"Failed to get metadata for slot {Slot}.", e);
                 }
 
+                if (publicKey is null)
+                {
+                    throw new Exception($"Failed to get public key for slot {Slot}, does there exist a key?");
+                }
+                if (Attestation.IsPresent)
+                {
+                    if (metadata.KeyStatus != PivKeyStatus.Generated)
+                    {
+                        throw new InvalidOperationException($"Private key must be generated on YubiKey for attested certificate requests. {Slot} is {metadata.KeyStatus}.");
+                    }
+                }
 
 
                 using AsymmetricAlgorithm dotNetPublicKey = KeyConverter.GetDotNetFromPivPublicKey(publicKey);

--- a/Module/types/Attestion.cs
+++ b/Module/types/Attestion.cs
@@ -21,7 +21,9 @@ namespace powershellYK
         public bool? isCSPNSeries { get; } = false;
         public bool? AttestionMatchesCSR { get; } = null;
 
-        public Attestion(bool attestionValidated = false, uint? serialnumber = null, FirmwareVersion? firmwareVersion = null, PivPinPolicy? pivPinPolicy = null, PivTouchPolicy? pivTouchPolicy = null, FormFactor? formFactor = null, PIVSlot? pivSlot = null, PivAlgorithm? pivAlgorithm = null, bool? isFIPSSeries = null, bool? isCSPNSeries = null, bool? AttestionMatchesCSR = null)
+        public string? AttestionDataLocation { get; } = null;
+
+        public Attestion(bool attestionValidated = false, uint? serialnumber = null, FirmwareVersion? firmwareVersion = null, PivPinPolicy? pivPinPolicy = null, PivTouchPolicy? pivTouchPolicy = null, FormFactor? formFactor = null, PIVSlot? pivSlot = null, PivAlgorithm? pivAlgorithm = null, bool? isFIPSSeries = null, bool? isCSPNSeries = null, bool? AttestionMatchesCSR = null, string? attestionDataLocation = null)
         {
             AttestionValidated = attestionValidated;
             this.SerialNumber = serialnumber;
@@ -34,6 +36,7 @@ namespace powershellYK
             this.isFIPSSeries = isFIPSSeries;
             this.isCSPNSeries = isCSPNSeries;
             this.AttestionMatchesCSR = AttestionMatchesCSR;
+            this.AttestionDataLocation = attestionDataLocation;
         }
     }
 }


### PR DESCRIPTION
- Making sure **Confirm-YubikeyAttestion**, allows for both YubiKey documentation .1 and yubico-piv-tool implementation .11 location of _Attestation Data_.
- Added data out put to say where _Attestation Data_ was located.
- Update **Build-YubikeyPIVCertificateSigningRequest** to give better error if KeyStatus is wrong.

In regard to #90, while I try to figure out where to store the _Attestation Data_ should be in a new CSR.