### PR TITLE
Fixing casing for K and Path handling

### DIFF
--- a/Docs/Commands/Confirm-YubikeyAttestion.md
+++ b/Docs/Commands/Confirm-YubikeyAttestion.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Confirm-YubikeyAttestion
+# Confirm-YubiKeyAttestion
 
 ## SYNOPSIS
 Confirm YubiKey Attestion.
@@ -14,24 +14,24 @@ Confirm YubiKey Attestion.
 
 ### requestWithExternalAttestion
 ```
-Confirm-YubikeyAttestion -CertificateRequest <PSObject> -AttestionCertificate <PSObject>
+Confirm-YubiKeyAttestion -CertificateRequest <PSObject> -AttestionCertificate <PSObject>
  -IntermediateCertificate <PSObject> [<CommonParameters>]
 ```
 
 ### requestWithBuiltinAttestion
 ```
-Confirm-YubikeyAttestion -CertificateRequest <PSObject> [<CommonParameters>]
+Confirm-YubiKeyAttestion -CertificateRequest <PSObject> [<CommonParameters>]
 ```
 
 ### JustAttestCertificate
 ```
-Confirm-YubikeyAttestion -AttestionCertificate <PSObject> -IntermediateCertificate <PSObject>
+Confirm-YubiKeyAttestion -AttestionCertificate <PSObject> -IntermediateCertificate <PSObject>
  [<CommonParameters>]
 ```
 
 ### CertificateIncludingAttestion
 ```
-Confirm-YubikeyAttestion -CertificateIncludingAttestion <PSObject> [<CommonParameters>]
+Confirm-YubiKeyAttestion -CertificateIncludingAttestion <PSObject> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -78,7 +78,7 @@ Verify the certificate request created by exported attestion and intermediate at
 Since this did not include a Certificate Request, *AttestionMatchesCSR* is null.
 
 ### Example 3
- ```powershell
+```powershell
 PS C:\> Confirm-YubikeyAttestion -CertificateRequest csr.pem -AttestionCertificate attestation.pem -IntermediateCertificate intermediate.pem
 
 AttestionValidated  : True

--- a/Docs/Commands/Connect-YubikeyFIDO2.md
+++ b/Docs/Commands/Connect-YubikeyFIDO2.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Connect-YubikeyFIDO2
+# Connect-YubiKeyFIDO2
 
 ## SYNOPSIS
 Connect to the FIDO2 session.
@@ -13,7 +13,7 @@ Connect to the FIDO2 session.
 ## SYNTAX
 
 ```
-Connect-YubikeyFIDO2 [-PIN <SecureString>] [<CommonParameters>]
+Connect-YubiKeyFIDO2 -PIN <SecureString> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -61,7 +61,7 @@ Type: SecureString
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Docs/Commands/powershellYK.md
+++ b/Docs/Commands/powershellYK.md
@@ -23,13 +23,13 @@ Creates a CSR for a slot in the YubiKey.
 ### [Build-YubikeyPIVSignCertificate](Build-YubikeyPIVSignCertificate.md)
 Sign a certificate request with a YubiKey.
 
-### [Confirm-YubikeyAttestion](Confirm-YubikeyAttestion.md)
+### [Confirm-YubiKeyAttestion](Confirm-YubiKeyAttestion.md)
 Confirm YubiKey Attestion.
 
 ### [Connect-Yubikey](Connect-Yubikey.md)
 Connect the module to the YubiKey.
 
-### [Connect-YubikeyFIDO2](Connect-YubikeyFIDO2.md)
+### [Connect-YubiKeyFIDO2](Connect-YubiKeyFIDO2.md)
 Connect to the FIDO2 session.
 
 ### [Connect-YubikeyOATH](Connect-YubikeyOATH.md)
@@ -65,7 +65,7 @@ Returns the connected YubiKey
 ### [Get-YubikeyFIDO2](Get-YubikeyFIDO2.md)
 Get FIDO2 information from YubiKey
 
-### [Get-YubikeyFIDO2Credentials](Get-YubikeyFIDO2Credentials.md)
+### [Get-YubikeyFIDO2Credential](Get-YubikeyFIDO2Credential.md)
 Read the FIDO2 discoverable credentials
 
 ### [Get-YubikeyOATH](Get-YubikeyOATH.md)

--- a/Docs/Examples/Generate YubiKey attestation and verify.md
+++ b/Docs/Examples/Generate YubiKey attestation and verify.md
@@ -1,0 +1,28 @@
+# Generate YubiKey attestation and verify
+
+The [powershellYK](https://github.com/virot/powershellYK) powershell7 module allows generation of YubiKey attestation.
+YubiKey attestation allows the proving that the private key resides and was generated on a geniuine YubiKey. This can also be bundled in the Certificate Signing Request to allow the Certificate Authority to verify the YubiKey before approving the request.
+
+The YubiKey contains a manufacture time private key and certificate signed by a private Yubico Certificate Authority.
+The intermediate attestation certificate is per YubiKey.
+
+## Generate attestion certificate and intermediate certificate
+```pwsh
+Assert-YubikeyPIV -Slot "PIV Authentication" -OutFile attestation.cer
+Export-YubikeyPIVCertificate -AttestationIntermediateCertificate -OutFile intermediate.cer
+```
+
+## Generate a Certificate Request with included attestion
+```pwsh
+Build-YubiKeyPIVCertificateSigningRequest -Slot "PIV Authentication" -Subjectname "CN=powershellYK" -Attestation -OutFile attested.csr -PEMEncoded
+```
+
+## Validate that a submitted attestion & intermediate certificates
+```pwsh
+Confirm-YubikeyAttestion -AttestionCertificate attestation.cer -IntermediateCertificate intermediate.cer
+```
+
+## Validate Certificate Request with included attestion
+```pwsh
+Confirm-YubikeyAttestion -CertificateRequest attested.csr
+```

--- a/Module/Cmdlets/FIDO2/ConnectYubikeyFIDO2.cs
+++ b/Module/Cmdlets/FIDO2/ConnectYubikeyFIDO2.cs
@@ -12,7 +12,7 @@ using System.Collections.ObjectModel;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Cmdlet(VerbsCommunications.Connect, "YubikeyFIDO2")]
+    [Cmdlet(VerbsCommunications.Connect, "YubiKeyFIDO2")]
 
     public class ConnectYubikeyFIDO2Command : PSCmdlet, IDynamicParameters
     {

--- a/Module/Cmdlets/FIDO2/EnableYubikeyFIDO2EnterpriseAttestation.cs
+++ b/Module/Cmdlets/FIDO2/EnableYubikeyFIDO2EnterpriseAttestation.cs
@@ -9,7 +9,7 @@ using powershellYK.support.validators;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Cmdlet(VerbsLifecycle.Enable, "YubikeyFIDO2EnterpriseAttestation", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsLifecycle.Enable, "YubiKeyFIDO2EnterpriseAttestation", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 
     public class EnableYubikeyFIDO2CmdletEnterpriseAttestation : PSCmdlet
     {

--- a/Module/Cmdlets/FIDO2/GetYubikeyFIDO2.cs
+++ b/Module/Cmdlets/FIDO2/GetYubikeyFIDO2.cs
@@ -7,7 +7,7 @@ using powershellYK.support;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Cmdlet(VerbsCommon.Get, "YubikeyFIDO2")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyFIDO2")]
 
     public class GetYubikeyFIDO2Cmdlet : PSCmdlet
     {

--- a/Module/Cmdlets/FIDO2/GetYubikeyFIDO2Credential.cs
+++ b/Module/Cmdlets/FIDO2/GetYubikeyFIDO2Credential.cs
@@ -7,8 +7,8 @@ using powershellYK.support;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Alias("Get-YubikeyFIDO2Credentials")]
-    [Cmdlet(VerbsCommon.Get, "YubikeyFIDO2Credential")]
+    [Alias("Get-YubiKeyFIDO2Credentials")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyFIDO2Credential")]
 
     public class GetYubikeyFIDO2CredentialsCommand : PSCmdlet
     {

--- a/Module/Cmdlets/FIDO2/ResetYubikeyFIDO2.cs
+++ b/Module/Cmdlets/FIDO2/ResetYubikeyFIDO2.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Cmdlet(VerbsCommon.Reset, "YubikeyFIDO2", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Reset, "YubiKeyFIDO2", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class ResetYubikeyFIDO2Cmdlet : PSCmdlet
     {
         private bool _yubiKeyRemoved = false;

--- a/Module/Cmdlets/FIDO2/SetYubikeyFIDO2.cs
+++ b/Module/Cmdlets/FIDO2/SetYubikeyFIDO2.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualBasic;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Cmdlet(VerbsCommon.Set, "YubikeyFIDO2")]
+    [Cmdlet(VerbsCommon.Set, "YubiKeyFIDO2")]
 
     public class SetYubikeyFIDO2Cmdlet : PSCmdlet, IDynamicParameters
     {

--- a/Module/Cmdlets/FIDO2/SetYubikeyFIDO2PIN.cs
+++ b/Module/Cmdlets/FIDO2/SetYubikeyFIDO2PIN.cs
@@ -9,7 +9,7 @@ using System.Collections.ObjectModel;
 
 namespace powershellYK.Cmdlets.Fido
 {
-    [Cmdlet(VerbsCommon.Set, "YubikeyFIDO2PIN")]
+    [Cmdlet(VerbsCommon.Set, "YubiKeyFIDO2PIN")]
 
     public class SetYubikeyFIDO2PINCmdlet : PSCmdlet, IDynamicParameters
     {

--- a/Module/Cmdlets/OATH/ConnectYubikeyOATH.cs
+++ b/Module/Cmdlets/OATH/ConnectYubikeyOATH.cs
@@ -10,7 +10,7 @@ using System.Security;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommunications.Connect, "YubikeyOATH", DefaultParameterSetName = "Password")]
+    [Cmdlet(VerbsCommunications.Connect, "YubiKeyOATH", DefaultParameterSetName = "Password")]
 
     public class ConnectYubikeyOATHCommand : Cmdlet
     {

--- a/Module/Cmdlets/OATH/GetYubikeyOATH.cs
+++ b/Module/Cmdlets/OATH/GetYubikeyOATH.cs
@@ -10,7 +10,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommon.Get, "YubikeyOATH")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyOATH")]
 
     public class GetYubikeyOATH2Command : Cmdlet
     {

--- a/Module/Cmdlets/OATH/GetYubikeyOATHAccount.cs
+++ b/Module/Cmdlets/OATH/GetYubikeyOATHAccount.cs
@@ -10,7 +10,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommon.Get, "YubikeyOATHAccount")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyOATHAccount")]
 
     public class GetYubikeyOATH2AccountlCommand : Cmdlet
     {

--- a/Module/Cmdlets/OATH/NewYubikeyOATHAccount.cs
+++ b/Module/Cmdlets/OATH/NewYubikeyOATHAccount.cs
@@ -10,7 +10,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommon.New, "YubikeyOATHAccount", DefaultParameterSetName = "TOTP")]
+    [Cmdlet(VerbsCommon.New, "YubiKeyOATHAccount", DefaultParameterSetName = "TOTP")]
 
     public class NewYubikeyOATH2AccountCommand : PSCmdlet
     {

--- a/Module/Cmdlets/OATH/ProtectYubikeyOATH.cs
+++ b/Module/Cmdlets/OATH/ProtectYubikeyOATH.cs
@@ -13,7 +13,7 @@ using System.Net.Security;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsSecurity.Protect, "YubikeyOATH")]
+    [Cmdlet(VerbsSecurity.Protect, "YubiKeyOATH")]
 
     public class SetYubikeyOATH2Command : PSCmdlet
     {

--- a/Module/Cmdlets/OATH/RemoveYubikeyOATHAccount.cs
+++ b/Module/Cmdlets/OATH/RemoveYubikeyOATHAccount.cs
@@ -5,7 +5,7 @@ using Yubico.YubiKey.Otp;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommon.Remove, "YubikeyOATHAccount", ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Remove, "YubiKeyOATHAccount", ConfirmImpact = ConfirmImpact.High)]
 
     public class RemoveYubikeyOATHAccountCommand : Cmdlet
     {

--- a/Module/Cmdlets/OATH/RenameYubikeyOATHAccount.cs
+++ b/Module/Cmdlets/OATH/RenameYubikeyOATHAccount.cs
@@ -5,7 +5,7 @@ using Yubico.YubiKey.Otp;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommon.Rename, "YubikeyOATHAccount")]
+    [Cmdlet(VerbsCommon.Rename, "YubiKeyOATHAccount")]
 
     public class RenameYubikeyOATHAccountCommand : Cmdlet
     {

--- a/Module/Cmdlets/OATH/RequestYubikeyOATHCode.cs
+++ b/Module/Cmdlets/OATH/RequestYubikeyOATHCode.cs
@@ -11,7 +11,7 @@ using System;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsLifecycle.Request, "YubikeyOATHCode", DefaultParameterSetName = "All")]
+    [Cmdlet(VerbsLifecycle.Request, "YubiKeyOATHCode", DefaultParameterSetName = "All")]
 
     public class GetYubikeyOATHCodeCommand : PSCmdlet
     {

--- a/Module/Cmdlets/OATH/ResetYubikeyOATH.cs
+++ b/Module/Cmdlets/OATH/ResetYubikeyOATH.cs
@@ -10,7 +10,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsCommon.Reset, "YubikeyOATH", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Reset, "YubiKeyOATH", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
 
     public class ResetYubikeyOATH2Command : Cmdlet
     {

--- a/Module/Cmdlets/OATH/UnprotectYubikeyOATH.cs
+++ b/Module/Cmdlets/OATH/UnprotectYubikeyOATH.cs
@@ -13,7 +13,7 @@ using System.Net.Security;
 
 namespace powershellYK.Cmdlets.OATH
 {
-    [Cmdlet(VerbsSecurity.Unprotect, "YubikeyOATH")]
+    [Cmdlet(VerbsSecurity.Unprotect, "YubiKeyOATH")]
 
     public class UnprotectYubikeyOATH2Command : PSCmdlet
     {

--- a/Module/Cmdlets/OTP/GetYubikeyOTP.cs
+++ b/Module/Cmdlets/OTP/GetYubikeyOTP.cs
@@ -10,7 +10,7 @@ using Yubico.YubiKey.Sample.PivSampleCode;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Get, "YubikeyOTP")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyOTP")]
     public class GetYubikeyOTPCommand : Cmdlet
     {
         protected override void BeginProcessing()

--- a/Module/Cmdlets/OTP/RemoveYubikeyOTP.cs
+++ b/Module/Cmdlets/OTP/RemoveYubikeyOTP.cs
@@ -8,7 +8,7 @@ using Yubico.YubiKey.Oath;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Remove, "YubikeyOTP", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Remove, "YubiKeyOTP", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class RemoveYubikeyOTPCommand : Cmdlet
     {
         //[ValidateOTPSlot()]

--- a/Module/Cmdlets/OTP/RequestYubikeyOTPChallange.cs
+++ b/Module/Cmdlets/OTP/RequestYubikeyOTPChallange.cs
@@ -14,7 +14,7 @@ using Yubico.YubiKey.Sample.PivSampleCode;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsLifecycle.Request, "YubikeyOTPChallange")]
+    [Cmdlet(VerbsLifecycle.Request, "YubiKeyOTPChallange")]
     public class RequestYubikeyOTPChallangeCommand : Cmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "YubiOTP Slot")]

--- a/Module/Cmdlets/OTP/SetYubikeyOTP.cs
+++ b/Module/Cmdlets/OTP/SetYubikeyOTP.cs
@@ -12,7 +12,7 @@ using Yubico.YubiKey.Otp.Operations;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Set, "YubikeyOTP", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Set, "YubiKeyOTP", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class SetYubikeyOTPCommand : PSCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Yubikey OTP Slot")]

--- a/Module/Cmdlets/OTP/SwitchYubikeyOTP.cs
+++ b/Module/Cmdlets/OTP/SwitchYubikeyOTP.cs
@@ -5,7 +5,7 @@ using Yubico.YubiKey.Otp;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Switch, "YubikeyOTP")]
+    [Cmdlet(VerbsCommon.Switch, "YubiKeyOTP")]
     public class SwitchYubikeyOTPCommand : Cmdlet
     {
         protected override void BeginProcessing()

--- a/Module/Cmdlets/Other/ConfirmYubikeyAttestion.cs
+++ b/Module/Cmdlets/Other/ConfirmYubikeyAttestion.cs
@@ -11,7 +11,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.Other
 {
-    [Cmdlet(VerbsLifecycle.Confirm, "YubikeyAttestion")]
+    [Cmdlet(VerbsLifecycle.Confirm, "YubiKeyAttestion")]
     public class ConfirmYubikeyAttestionCommand : PSCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "CSR to check", ParameterSetName = "requestWithExternalAttestion")]

--- a/Module/Cmdlets/PIV/AssertYubiKeyPIV.cs
+++ b/Module/Cmdlets/PIV/AssertYubiKeyPIV.cs
@@ -4,6 +4,7 @@ using Yubico.YubiKey;
 using Yubico.YubiKey.Piv;
 using System.Security.Cryptography;
 using powershellYK.PIV;
+using powershellYK.support.transform;
 
 
 namespace powershellYK.Cmdlets.PIV
@@ -16,7 +17,7 @@ namespace powershellYK.Cmdlets.PIV
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Yubikey PIV Slot", ParameterSetName = "ExportToFile")]
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Yubikey PIV Slot", ParameterSetName = "DisplayOnScreen")]
         public PIVSlot Slot { get; set; }
-
+        [TransformPath()]
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Location of the attestation certificate", ParameterSetName = "ExportToFile")]
         public string? OutFile { get; set; } = null;
 
@@ -57,6 +58,7 @@ namespace powershellYK.Cmdlets.PIV
                 string pemData = PemEncoding.WriteString("CERTIFICATE", slotAttestationCertificateBytes);
                 if (OutFile is not null)
                 {
+                    WriteDebug($"Writing Attestation certificate to {OutFile}");
                     File.WriteAllText(OutFile, pemData);
                 }
                 else

--- a/Module/Cmdlets/PIV/AssertYubiKeyPIV.cs
+++ b/Module/Cmdlets/PIV/AssertYubiKeyPIV.cs
@@ -8,7 +8,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsLifecycle.Assert, "YubikeyPIV")]
+    [Cmdlet(VerbsLifecycle.Assert, "YubiKeyPIV")]
     public class AssertYubiKeyPIVCommand : PSCmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/BlockYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/BlockYubikeyPIV.cs
@@ -8,7 +8,7 @@ using Yubico.YubiKey.Piv.Commands;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsSecurity.Block, "YubikeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Low)]
+    [Cmdlet(VerbsSecurity.Block, "YubiKeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Low)]
     public class BlockYubikeyPIVCommand : Cmdlet
     {
 

--- a/Module/Cmdlets/PIV/BuildYubikeyPIVSignCertificate.cs
+++ b/Module/Cmdlets/PIV/BuildYubikeyPIVSignCertificate.cs
@@ -10,7 +10,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsLifecycle.Build, "YubikeyPIVSignCertificate")]
+    [Cmdlet(VerbsLifecycle.Build, "YubiKeyPIVSignCertificate")]
     public class BuildYubikeySignedCertificateCommand : Cmdlet
     {
         [TransformCertificateRequest_Path()]

--- a/Module/Cmdlets/PIV/ConnectYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/ConnectYubikeyPIV.cs
@@ -13,7 +13,7 @@ using powershellYK.support.transform;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommunications.Connect, "YubikeyPIV", DefaultParameterSetName = "PIN")]
+    [Cmdlet(VerbsCommunications.Connect, "YubiKeyPIV", DefaultParameterSetName = "PIN")]
 
     public class ConnectYubikeyPIVCommand : Cmdlet
     {

--- a/Module/Cmdlets/PIV/ExportYubiKeyPIVCertificate.cs
+++ b/Module/Cmdlets/PIV/ExportYubiKeyPIVCertificate.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography.X509Certificates;
 using Yubico.YubiKey.Piv;
 using Yubico.YubiKey;
 using powershellYK.PIV;
+using powershellYK.support.transform;
 
 
 namespace powershellYK.Cmdlets.PIV
@@ -17,7 +18,7 @@ namespace powershellYK.Cmdlets.PIV
         [Alias("AttestationCertificate")]
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Export Attestation certificate", ParameterSetName = "AttestationCertificate")]
         public SwitchParameter AttestationIntermediateCertificate { get; set; }
-
+        [TransformPath()]
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Output file")]
         public string? OutFile { get; set; } = null;
 
@@ -70,6 +71,7 @@ namespace powershellYK.Cmdlets.PIV
 
                 if (OutFile is not null)
                 {
+                    WriteCommandDetail($"Writing certificate to {OutFile}");
                     File.WriteAllText(OutFile, pemData);
                 }
                 else

--- a/Module/Cmdlets/PIV/ExportYubiKeyPIVCertificate.cs
+++ b/Module/Cmdlets/PIV/ExportYubiKeyPIVCertificate.cs
@@ -8,7 +8,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsData.Export, "YubikeyPIVCertificate")]
+    [Cmdlet(VerbsData.Export, "YubiKeyPIVCertificate")]
     public class ExportYubiKeyPIVCertificateCommand : Cmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/GetYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/GetYubikeyPIV.cs
@@ -10,7 +10,7 @@ using Yubico.YubiKey.Sample.PivSampleCode;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Get, "YubikeyPIV")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyPIV")]
     public class GetYubikeyPIVCommand : PSCmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/ImportYubiKeyPIV.cs
+++ b/Module/Cmdlets/PIV/ImportYubiKeyPIV.cs
@@ -13,7 +13,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsData.Import, "YubikeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsData.Import, "YubiKeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class ImportYubiKeyPIVCommand : PSCmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/MoveYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/MoveYubikeyPIV.cs
@@ -7,7 +7,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Move, "YubikeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Move, "YubiKeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class MoveYubiKeyPIVCmdlet : Cmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/NewYubiKeyPIVSelfSign.cs
+++ b/Module/Cmdlets/PIV/NewYubiKeyPIVSelfSign.cs
@@ -10,7 +10,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.New, "YubikeyPIVSelfSign", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.New, "YubiKeyPIVSelfSign", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class NewYubiKeyPIVSelfSignCommand : Cmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/NewYubikeyPIVKey.cs
+++ b/Module/Cmdlets/PIV/NewYubikeyPIVKey.cs
@@ -9,7 +9,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.New, "YubikeyPIVKey", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.New, "YubiKeyPIVKey", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class NewYubiKeyPIVKeyCommand : PSCmdlet, IDynamicParameters
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/RemoveYubikeyPIVKey.cs
+++ b/Module/Cmdlets/PIV/RemoveYubikeyPIVKey.cs
@@ -6,7 +6,7 @@ using powershellYK.PIV;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Remove, "YubikeyPIVKey", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Remove, "YubiKeyPIVKey", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class RemoveYubiKeyPIVKeyCmdlet : Cmdlet
     {
         [ArgumentCompletions("\"PIV Authentication\"", "\"Digital Signature\"", "\"Key Management\"", "\"Card Authentication\"", "0x9a", "0x9c", "0x9d", "0x9e")]

--- a/Module/Cmdlets/PIV/ResetYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/ResetYubikeyPIV.cs
@@ -6,7 +6,7 @@ using Yubico.YubiKey.Piv.Commands;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Reset, "YubikeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Reset, "YubiKeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     [OutputType(typeof(bool))]
     public class ResetYubikeyPIVCommand : Cmdlet
     {

--- a/Module/Cmdlets/PIV/SetYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/SetYubikeyPIV.cs
@@ -13,7 +13,7 @@ using powershellYK.support.validators;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Set, "YubikeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Set, "YubiKeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class SetYubikeyPIVCommand : PSCmdlet
     {
 

--- a/Module/Cmdlets/PIV/UnblockYubikeyPIV.cs
+++ b/Module/Cmdlets/PIV/UnblockYubikeyPIV.cs
@@ -13,7 +13,7 @@ using powershellYK.support.validators;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsSecurity.Unblock, "YubikeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsSecurity.Unblock, "YubiKeyPIV", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class UnblockYubikeyPIVCmdlet : Cmdlet
     {
 

--- a/Module/Cmdlets/UV/GetYubikeyUVFingerprint.cs
+++ b/Module/Cmdlets/UV/GetYubikeyUVFingerprint.cs
@@ -11,7 +11,7 @@ using powershellYK.UserValidation;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Get, "YubikeyUVFingerprint")]
+    [Cmdlet(VerbsCommon.Get, "YubiKeyUVFingerprint")]
     public class GetYubikeyUVFingerprintCmdlet : Cmdlet
     {
 

--- a/Module/Cmdlets/UV/RegisterYubikeyUVFingerprint.cs
+++ b/Module/Cmdlets/UV/RegisterYubikeyUVFingerprint.cs
@@ -12,7 +12,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsLifecycle.Register, "YubikeyUVFingerprint")]
+    [Cmdlet(VerbsLifecycle.Register, "YubiKeyUVFingerprint")]
     public class RegisterYubikeyUVFingerprintCmdlet : Cmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Name of the finger to register")]

--- a/Module/Cmdlets/UV/RemoveYubikeyUVFingerprint.cs
+++ b/Module/Cmdlets/UV/RemoveYubikeyUVFingerprint.cs
@@ -12,7 +12,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Remove, "YubikeyUVFingerprint", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Remove, "YubiKeyUVFingerprint", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class RemoveYubikeyUVFingerprintCmdlet : PSCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Name of finger to remove", ParameterSetName = "Remove using Name")]

--- a/Module/Cmdlets/UV/RenameYubikeyUVFingerprint.cs
+++ b/Module/Cmdlets/UV/RenameYubikeyUVFingerprint.cs
@@ -12,7 +12,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.PIV
 {
-    [Cmdlet(VerbsCommon.Rename, "YubikeyUVFingerprint")]
+    [Cmdlet(VerbsCommon.Rename, "YubiKeyUVFingerprint")]
     public class RenameYubikeyUVFingerprintCmdlet : PSCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Friendly name of fingerprint to rename", ParameterSetName = "Rename using Name")]

--- a/Module/Cmdlets/Yubikey/ConnectYubikey.cs
+++ b/Module/Cmdlets/Yubikey/ConnectYubikey.cs
@@ -7,7 +7,7 @@ using Yubico.YubiKey.Sample.PivSampleCode;
 
 namespace powershellYK.Cmdlets.Yubikey
 {
-    [Cmdlet(VerbsCommunications.Connect, "Yubikey", DefaultParameterSetName = "Connect single Yubikey")]
+    [Cmdlet(VerbsCommunications.Connect, "YubiKey", DefaultParameterSetName = "Connect single Yubikey")]
     public class ConnectYubikeyCommand : PSCmdlet
     {
 

--- a/Module/Cmdlets/Yubikey/DisconnectYubikey.cs
+++ b/Module/Cmdlets/Yubikey/DisconnectYubikey.cs
@@ -4,7 +4,7 @@ using Yubico.YubiKey;
 
 namespace powershellYK.Cmdlets.Yubikey
 {
-    [Cmdlet(VerbsCommunications.Disconnect, "Yubikey")]
+    [Cmdlet(VerbsCommunications.Disconnect, "YubiKey")]
     public class DisconnectYubikeyCommand : Cmdlet
     {
         protected override void BeginProcessing()

--- a/Module/Cmdlets/Yubikey/FindYubikey.cs
+++ b/Module/Cmdlets/Yubikey/FindYubikey.cs
@@ -3,7 +3,7 @@ using Yubico.YubiKey;
 
 namespace powershellYK.Cmdlets.Yubikey
 {
-    [Cmdlet(VerbsCommon.Find, "Yubikey")]
+    [Cmdlet(VerbsCommon.Find, "YubiKey")]
     public class FindYubikeyCommand : Cmdlet
     {
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Return only one YubiKey")]

--- a/Module/Cmdlets/Yubikey/GetYubikey.cs
+++ b/Module/Cmdlets/Yubikey/GetYubikey.cs
@@ -4,7 +4,7 @@ using powershellYK.YubiKey;
 
 namespace powershellYK.Cmdlets.Yubikey
 {
-    [Cmdlet(VerbsCommon.Get, "Yubikey")]
+    [Cmdlet(VerbsCommon.Get, "YubiKey")]
     public class GetYubikeyCommand : PSCmdlet
     {
         protected override void BeginProcessing()

--- a/Module/Cmdlets/Yubikey/LockYubikey.cs
+++ b/Module/Cmdlets/Yubikey/LockYubikey.cs
@@ -4,7 +4,7 @@ using Yubico.YubiKey.Management.Commands;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Lock, "Yubikey")]
+    [Cmdlet(VerbsCommon.Lock, "YubiKey")]
     public class LockYubikeyCommand : PSCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "LockCode for Yubikey")]

--- a/Module/Cmdlets/Yubikey/SetYubikey.cs
+++ b/Module/Cmdlets/Yubikey/SetYubikey.cs
@@ -13,7 +13,7 @@ using Yubico.YubiKey.Piv;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Set, "Yubikey", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
+    [Cmdlet(VerbsCommon.Set, "YubiKey", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class SetYubikeyCommand : PSCmdlet
     {
 

--- a/Module/Cmdlets/Yubikey/UnlockYubikey.cs
+++ b/Module/Cmdlets/Yubikey/UnlockYubikey.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace powershellYK.Cmdlets.OTP
 {
-    [Cmdlet(VerbsCommon.Unlock, "Yubikey")]
+    [Cmdlet(VerbsCommon.Unlock, "YubiKey")]
     public class UnlockYubikeyCommand : PSCmdlet
     {
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Lock Code for YubiKey")]

--- a/Module/support/transform/TransformPath.cs
+++ b/Module/support/transform/TransformPath.cs
@@ -14,18 +14,18 @@ namespace powershellYK.support.transform
         {
             if (inputData is string)
             {
-                // there is a bug with GetCurrentDirectory, which breaks relative paths
-                var myPowersShellInstance = PowerShell.Create(RunspaceMode.CurrentRunspace).AddCommand("Resolve-Path");
-                myPowersShellInstance.AddParameter("Path", inputData);
-                myPowersShellInstance.AddCommand("Select-Object").AddParameter("ExpandProperty", "Path");
-                System.Collections.ObjectModel.Collection<System.Management.Automation.PSObject> returnValue = myPowersShellInstance.Invoke();
-                string? newPath = returnValue.FirstOrDefault()?.BaseObject.ToString();
-                if (System.IO.File.Exists(newPath))
+                // fix relative paths
+                if (! Path.IsPathFullyQualified(inputData?.ToString() ?? ""))
                 {
-                    return newPath;
-                }
+                    var sessionState = engineIntrinsics.SessionState;
+                    return Path.Combine(sessionState.Path.CurrentFileSystemLocation.ToString(), inputData?.ToString() ?? "");
+                }                
             }
-            return inputData;
+            return inputData!;
+        }
+
+        public TransformPath()
+        {
         }
     }
 }

--- a/Pester/290-Confirm-YubikeyAttestion.tests.ps1
+++ b/Pester/290-Confirm-YubikeyAttestion.tests.ps1
@@ -6,7 +6,7 @@ Describe "Confirm-YubikeyAttestion requestWithBuiltinAttestion" -Tag "Without-Yu
         #Get-Variable pest*|Remove-Variable
     }
 
-    It -Name "Verify 'Confirm-YubikeyAttestion -CertificateRequest _fullfile_' works, Windows" -Skip:(!$IsWindows) -Test {
+    It -Name "Verify 'Confirm-YubiKeyAttestion -CertificateRequest _fullfile_' works, Windows" -Skip:(!$IsWindows) -Test {
         $pest_return = Confirm-YubikeyAttestion -CertificateRequest "$PSScriptRoot\TestData\piv_attestion_certificaterequest_with_attestion.req"
         $pest_return | Should -BeOfType powershellYK.Attestion
         $pest_return.Slot | Should -Be 0x9a


### PR DESCRIPTION
* Fix casing on K in YubiKey for the Cmdlets
* Rename Fido folder to FIDO2
* Fix TransformPath and use on Assert-YubiKeyPIV, Export-YubiKeyPIVCertificate
* Add example on how to use YubiKey attestation