### PR TITLE
Updates to file handling and PIV exports

### DIFF
--- a/Docs/Commands/Assert-YubikeyPIV.md
+++ b/Docs/Commands/Assert-YubikeyPIV.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Assert-YubikeyPIV
+# Assert-YubiKeyPIV
 
 ## SYNOPSIS
 Create attestation certificate
@@ -14,12 +14,12 @@ Create attestation certificate
 
 ### ExportToFile
 ```
-Assert-YubikeyPIV -Slot <PIVSlot> -OutFile <String> [<CommonParameters>]
+Assert-YubiKeyPIV -Slot <PIVSlot> -OutFile <FileInfo> [<CommonParameters>]
 ```
 
 ### DisplayOnScreen
 ```
-Assert-YubikeyPIV -Slot <PIVSlot> [-PEMEncoded] [<CommonParameters>]
+Assert-YubiKeyPIV -Slot <PIVSlot> [-PEMEncoded] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,7 +40,7 @@ Creates and exports the attestation certificate for slot 0x9a
 Location of attestation certificate
 
 ```yaml
-Type: String
+Type: FileInfo
 Parameter Sets: ExportToFile
 Aliases:
 

--- a/Docs/Commands/Build-YubiKeyPIVCertificateSigningRequest.md
+++ b/Docs/Commands/Build-YubiKeyPIVCertificateSigningRequest.md
@@ -14,7 +14,7 @@ Creates a CSR for a slot in the YubiKey.
 
 ```
 Build-YubiKeyPIVCertificateSigningRequest -Slot <PIVSlot> [-Attestation] [-Subjectname <String>]
- [-OutFile <String>] [-HashAlgorithm <HashAlgorithmName>] [-PEMEncoded] [<CommonParameters>]
+ [-OutFile <FileInfo>] [-HashAlgorithm <HashAlgorithmName>] [-PEMEncoded] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 Save CSR as file
 
 ```yaml
-Type: String
+Type: FileInfo
 Parameter Sets: (All)
 Aliases:
 

--- a/Docs/Commands/Build-YubikeyPIVSignCertificate.md
+++ b/Docs/Commands/Build-YubikeyPIVSignCertificate.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Build-YubikeyPIVSignCertificate
+# Build-YubiKeyPIVSignCertificate
 
 ## SYNOPSIS
 Sign a certificate request with a YubiKey.
@@ -13,8 +13,8 @@ Sign a certificate request with a YubiKey.
 ## SYNTAX
 
 ```
-Build-YubikeyPIVSignCertificate -CertificateRequest <PSObject> -Slot <PIVSlot>
- [-HashAlgorithm <HashAlgorithmName>] [-OutFile <String>] [-PEMEncoded] [-Subjectname <String>]
+Build-YubiKeyPIVSignCertificate -CertificateRequest <PSObject> -Slot <PIVSlot>
+ [-HashAlgorithm <HashAlgorithmName>] [-OutFile <FileInfo>] [-PEMEncoded] [-Subjectname <String>]
  [-NotBefore <DateTimeOffset>] [-NotAfter <DateTimeOffset>] [-SerialNumber <Byte[]>] [-CertificateAuthority]
  [-SubjectAltName <String[]>] [-KeyUsage <X509KeyUsageFlags>] [-AIAUrl <String>] [<CommonParameters>]
 ```
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 Output file
 
 ```yaml
-Type: String
+Type: FileInfo
 Parameter Sets: (All)
 Aliases:
 

--- a/Docs/Commands/Export-YubikeyPIVCertificate.md
+++ b/Docs/Commands/Export-YubikeyPIVCertificate.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Export-YubikeyPIVCertificate
+# Export-YubiKeyPIVCertificate
 
 ## SYNOPSIS
 Export certificate from YubiKey PIV
@@ -14,12 +14,12 @@ Export certificate from YubiKey PIV
 
 ### Slot
 ```
-Export-YubikeyPIVCertificate -Slot <PIVSlot> [-OutFile <String>] [-PEMEncoded] [<CommonParameters>]
+Export-YubiKeyPIVCertificate -Slot <PIVSlot> [-OutFile <FileInfo>] [-PEMEncoded] [<CommonParameters>]
 ```
 
 ### AttestationCertificate
 ```
-Export-YubikeyPIVCertificate [-AttestationIntermediateCertificate] [-OutFile <String>] [-PEMEncoded]
+Export-YubiKeyPIVCertificate [-AttestationIntermediateCertificate] [-OutFile <FileInfo>] [-PEMEncoded]
  [<CommonParameters>]
 ```
 
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 Output file
 
 ```yaml
-Type: String
+Type: FileInfo
 Parameter Sets: (All)
 Aliases:
 

--- a/Docs/Commands/Import-YubikeyPIV.md
+++ b/Docs/Commands/Import-YubikeyPIV.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Import-YubikeyPIV
+# Import-YubiKeyPIV
 
 ## SYNOPSIS
 Import certificate
@@ -14,24 +14,24 @@ Import certificate
 
 ### CertificateOnly
 ```
-Import-YubikeyPIV -Slot <PIVSlot> -Certificate <Object> [-WhatIf] [-Confirm] [<CommonParameters>]
+Import-YubiKeyPIV -Slot <PIVSlot> -Certificate <Object> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### CertificateAndKey
 ```
-Import-YubikeyPIV -Slot <PIVSlot> -Certificate <Object> -PrivateKeyPath <String> [-Password <SecureString>]
+Import-YubiKeyPIV -Slot <PIVSlot> -Certificate <Object> -PrivateKeyPath <FileInfo> [-Password <SecureString>]
  [-PinPolicy <PivPinPolicy>] [-TouchPolicy <PivTouchPolicy>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### P12
 ```
-Import-YubikeyPIV -Slot <PIVSlot> -P12Path <String> [-Password <SecureString>] [-PinPolicy <PivPinPolicy>]
+Import-YubiKeyPIV -Slot <PIVSlot> -P12Path <FileInfo> [-Password <SecureString>] [-PinPolicy <PivPinPolicy>]
  [-TouchPolicy <PivTouchPolicy>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Privatekey
 ```
-Import-YubikeyPIV -Slot <PIVSlot> -PrivateKeyPath <String> [-Password <SecureString>]
+Import-YubiKeyPIV -Slot <PIVSlot> -PrivateKeyPath <FileInfo> [-Password <SecureString>]
  [-PinPolicy <PivPinPolicy>] [-TouchPolicy <PivTouchPolicy>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 P12 file to be stored
 
 ```yaml
-Type: String
+Type: FileInfo
 Parameter Sets: P12
 Aliases:
 
@@ -121,7 +121,7 @@ Accept wildcard characters: False
 Private key to be stored
 
 ```yaml
-Type: String
+Type: FileInfo
 Parameter Sets: CertificateAndKey, Privatekey
 Aliases:
 

--- a/Docs/Commands/New-YubikeyPIVKey.md
+++ b/Docs/Commands/New-YubikeyPIVKey.md
@@ -46,7 +46,7 @@ Create a RSA2048 in slot 0x9a with a touch policy of cached
 ## PARAMETERS
 
 ### -Algorithm
-What algorithm to use
+What algorithm to use, dependent on YubiKey firmware.
 
 ```yaml
 Type: PivAlgorithm

--- a/Module/Cmdlets/PIV/BuildYubikeyPIVSignCertificate.cs
+++ b/Module/Cmdlets/PIV/BuildYubikeyPIVSignCertificate.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using Yubico.YubiKey.Sample.PivSampleCode;
 using powershellYK.support.transform;
 using powershellYK.PIV;
+using powershellYK.support.validators;
 
 
 namespace powershellYK.Cmdlets.PIV
@@ -22,9 +23,9 @@ namespace powershellYK.Cmdlets.PIV
         [ValidateSet("SHA1", "SHA256", "SHA384", "SHA512", IgnoreCase = true)]
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "HashAlgoritm")]
         public HashAlgorithmName HashAlgorithm { get; set; } = HashAlgorithmName.SHA256;
-        [TransformPath()]
+        [ValidatePath(fileMustExist: false, fileMustNotExist: true)]
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Output file")]
-        public string? OutFile { get; set; } = null;
+        public System.IO.FileInfo? OutFile { get; set; } = null;
 
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Encode output as PEM")]
         public SwitchParameter PEMEncoded { get; set; }
@@ -184,7 +185,12 @@ namespace powershellYK.Cmdlets.PIV
 
                 if (OutFile is not null)
                 {
-                    File.WriteAllText(OutFile, pemData);
+                    WriteCommandDetail($"Writing certificate to {OutFile.FullName}");
+                    using (FileStream stream = OutFile.OpenWrite())
+                    {
+                        byte[] pemDataArray = System.Text.Encoding.UTF8.GetBytes(pemData);
+                        stream.Write(pemDataArray, 0, pemDataArray.Length);
+                    }
                 }
                 else
                 {

--- a/Module/Cmdlets/PIV/ImportYubiKeyPIV.cs
+++ b/Module/Cmdlets/PIV/ImportYubiKeyPIV.cs
@@ -109,7 +109,7 @@ namespace powershellYK.Cmdlets.PIV
                         //https://github.com/dotnet/runtime/issues/36899
                     }
                     int keySize = newECDsaPrivateKey.KeySize / 8;
-                    eccParam = newECDsaPrivateKey.ExportParameters(true); 
+                    eccParam = newECDsaPrivateKey.ExportParameters(true);
                     byte[] privateKey = new byte[keySize];
                     int offset = keySize - eccParam.D!.Length;
                     Array.Copy(eccParam.D, 0, privateKey, offset, eccParam.D.Length);

--- a/Module/support/validators/ValidatePath.cs
+++ b/Module/support/validators/ValidatePath.cs
@@ -6,14 +6,28 @@ namespace powershellYK.support.validators
 {
     public class ValidatePath : ValidateArgumentsAttribute
     {
-        public string _fileExt { get; } = "";
+        public string? _fileExt { get; } = "";
+        public bool _fileMustExist { get; } = false;
+        public bool _fileMustNotExist { get; } = false;
         protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
         {
-            if (!Path.Exists((string)arguments))
+            if (arguments is System.IO.FileInfo && _fileMustExist && !((FileInfo)arguments).Exists)
+            {
+                throw new ArgumentException($"Path {((FileInfo)arguments).FullName} does not exist.");
+            }
+            if (arguments is System.IO.FileInfo && _fileMustNotExist && ((FileInfo)arguments).Exists)
+            {
+                throw new ArgumentException($"Path {((FileInfo)arguments).FullName} already exists.");
+            }
+            if (arguments is System.IO.FileInfo && _fileMustNotExist && ((FileInfo)arguments).Extension == _fileExt )
+            {
+                throw new ArgumentException($"Path {((FileInfo)arguments).FullName} does not end in required {_fileExt}.");
+            }
+            if (arguments is string && !Path.Exists((string)arguments))
             {
                 throw new ArgumentException($"Path {arguments} does not exist.");
             }
-            if (!((string)arguments).EndsWith(_fileExt))
+            if (arguments is string && _fileExt is not null && !((string)arguments).EndsWith(_fileExt))
             {
                 throw new ArgumentException($"Path {arguments} needs to end with {_fileExt}.");
             }
@@ -25,6 +39,12 @@ namespace powershellYK.support.validators
         }
         public ValidatePath()
         {
+        }
+        public ValidatePath(bool fileMustExist, bool fileMustNotExist, string? fileExt = null)
+        {
+            this._fileMustExist = fileMustExist;
+            this._fileMustNotExist = fileMustNotExist;
+            this._fileExt = fileExt;
         }
     }
 

--- a/Module/support/validators/ValidatePath.cs
+++ b/Module/support/validators/ValidatePath.cs
@@ -19,7 +19,7 @@ namespace powershellYK.support.validators
             {
                 throw new ArgumentException($"Path {((FileInfo)arguments).FullName} already exists.");
             }
-            if (arguments is System.IO.FileInfo && _fileMustNotExist && ((FileInfo)arguments).Extension == _fileExt )
+            if (arguments is System.IO.FileInfo && _fileMustNotExist && ((FileInfo)arguments).Extension == _fileExt)
             {
                 throw new ArgumentException($"Path {((FileInfo)arguments).FullName} does not end in required {_fileExt}.");
             }


### PR DESCRIPTION
Change to FileInfo from String
Make sure commands dont overwrite files that exists
Allow export of slot f9 without specifying -AttestationIntermediateCertificate/AttestationCertificate