### PR TITLE
Build-YubiKeyPIVCertificateSigningRequest changes

### DIFF
--- a/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
+++ b/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
@@ -168,7 +168,8 @@ namespace powershellYK.Cmdlets.PIV
                     }
                     else
                     {
-                        WriteObject(requestSigned);
+                        var csrObject = CertificateRequest.LoadSigningRequestPem(pemData.AsSpan(), HashAlgorithm, CertificateRequestLoadOptions.UnsafeLoadCertificateExtensions);
+                        WriteObject(csrObject);
                     }
                 }
                 WriteDebug("ProcessRecord in New-YubikeyPIVCSR");

--- a/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
+++ b/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
@@ -70,7 +70,7 @@ namespace powershellYK.Cmdlets.PIV
                 {
                     throw new NotSupportedException("This feature requires firmware version 5.3.0 or newer.");
                 }
-                
+
                 // get the metadata catch if fails
                 PivMetadata? metadata = null;
                 PivPublicKey? publicKey = null;

--- a/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
+++ b/Module/Cmdlets/PIV/BuildYubiKeyPIVCertificateSigningRequest.cs
@@ -65,7 +65,13 @@ namespace powershellYK.Cmdlets.PIV
                 CertificateRequest request;
                 X509SignatureGenerator signer;
 
-                // get the metadata catch if fails                
+                // This is only supported on firmware 5.3.0 and newer.
+                if (((YubiKeyDevice)YubiKeyModule._yubikey!).FirmwareVersion < new FirmwareVersion(5, 3, 0))
+                {
+                    throw new NotSupportedException("This feature requires firmware version 5.3.0 or newer.");
+                }
+                
+                // get the metadata catch if fails
                 PivMetadata? metadata = null;
                 PivPublicKey? publicKey = null;
                 try


### PR DESCRIPTION
- Add error handling that current logic requires 5.3.0
- Return *System.Security.Cryptography.X509Certificates.CertificateRequest*