### PR TITLE
Added HOTP to slot programming

### DIFF
--- a/Docs/Commands/Set-YubikeyOTP.md
+++ b/Docs/Commands/Set-YubikeyOTP.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Set-YubikeyOTP
+# Set-YubiKeyOTP
 
 ## SYNOPSIS
 Configure OTP slots
@@ -14,26 +14,32 @@ Configure OTP slots
 
 ### Yubico OTP
 ```
-Set-YubikeyOTP -Slot <Slot> [-YubicoOTP] [-PublicID <Byte[]>] [-PrivateID <Byte[]>] [-SecretKey <Byte[]>]
+Set-YubiKeyOTP -Slot <Slot> [-YubicoOTP] [-PublicID <Byte[]>] [-PrivateID <Byte[]>] [-SecretKey <Byte[]>]
  [-Upload] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Static Password
 ```
-Set-YubikeyOTP -Slot <Slot> [-StaticPassword] -Password <SecureString> [-KeyboardLayout <KeyboardLayout>]
+Set-YubiKeyOTP -Slot <Slot> [-StaticPassword] -Password <SecureString> [-KeyboardLayout <KeyboardLayout>]
  [-AppendCarriageReturn] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Static Generated Password
 ```
-Set-YubikeyOTP -Slot <Slot> [-StaticGeneratedPassword] -PasswordLength <Int32>
+Set-YubiKeyOTP -Slot <Slot> [-StaticGeneratedPassword] -PasswordLength <Int32>
  [-KeyboardLayout <KeyboardLayout>] [-AppendCarriageReturn] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ChallengeResponse
 ```
-Set-YubikeyOTP -Slot <Slot> [-ChallengeResponse] [-SecretKey <Byte[]>]
+Set-YubiKeyOTP -Slot <Slot> [-ChallengeResponse] [-SecretKey <Byte[]>]
  [-Algorithm <ChallengeResponseAlgorithm>] [-RequireTouch] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### HOTP
+```
+Set-YubiKeyOTP -Slot <Slot> [-SecretKey <Byte[]>] [-AppendCarriageReturn] [-HOTP] [-Base32Secret <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -105,7 +111,22 @@ field and "pressing Enter" on behalf of the user.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Static Password, Static Generated Password
+Parameter Sets: Static Password, Static Generated Password, HOTP
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Base32Secret
+Base32 encoded secret key for HOTP
+
+```yaml
+Type: String
+Parameter Sets: HOTP
 Aliases:
 
 Required: False
@@ -121,6 +142,21 @@ Allows for Challenge-Response configuration with all defaults.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: ChallengeResponse
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HOTP
+Allows configuration of HOTP mode
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: HOTP
 Aliases:
 
 Required: False
@@ -226,7 +262,7 @@ Sets the Secret Key, defaults to random 16 bytes.
 
 ```yaml
 Type: Byte[]
-Parameter Sets: Yubico OTP, ChallengeResponse
+Parameter Sets: Yubico OTP, ChallengeResponse, HOTP
 Aliases:
 
 Required: False

--- a/Module/Cmdlets/OTP/SetYubikeyOTP.cs
+++ b/Module/Cmdlets/OTP/SetYubikeyOTP.cs
@@ -1,9 +1,59 @@
-﻿using System.Management.Automation;
+﻿/// <summary>
+/// Configures OTP (One-Time Password) settings on a YubiKey device.
+/// Supports multiple OTP modes including Yubico OTP, Static Password, and Challenge-Response.
+/// Can configure either the short-press or long-press slot on the YubiKey.
+/// 
+/// .EXAMPLE
+/// # Configure Yubico OTP with default settings
+/// Set-YubiKeyOTP -Slot ShortPress -YubicoOTP
+/// 
+/// .EXAMPLE
+/// # Configure Yubico OTP with custom settings
+/// $publicId = [byte[]]@(1,2,3,4,5,6)
+/// $privateId = [byte[]]@(7,8,9,10,11,12)
+/// $secretKey = [byte[]]@(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+/// Set-YubiKeyOTP -Slot LongPress -YubicoOTP -PublicID $publicId -PrivateID $privateId -SecretKey $secretKey
+/// 
+/// .EXAMPLE
+/// # Configure static password
+/// $securePassword = ConvertTo-SecureString "MySecretPassword" -AsPlainText -Force
+/// Set-YubiKeyOTP -Slot ShortPress -StaticPassword -Password $securePassword -KeyboardLayout US -AppendCarriageReturn
+/// 
+/// .EXAMPLE
+/// # Configure generated static password
+/// Set-YubiKeyOTP -Slot LongPress -StaticGeneratedPassword -PasswordLength 32 -KeyboardLayout ModHex
+/// 
+/// .EXAMPLE
+/// # Configure Challenge-Response with HMAC-SHA1
+/// Set-YubiKeyOTP -Slot ShortPress -ChallengeResponse -Algorithm HmacSha1 -RequireTouch
+/// 
+/// .EXAMPLE
+/// # Configure Challenge-Response with custom key
+/// $secretKey = [byte[]]@(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20)
+/// Set-YubiKeyOTP -Slot LongPress -ChallengeResponse -SecretKey $secretKey -Algorithm YubicoOtp
+/// 
+/// .EXAMPLE
+/// # Configure HOTP with default settings
+/// Set-YubiKeyOTP -Slot ShortPress -HOTP
+/// 
+/// .EXAMPLE
+/// # Configure HOTP with custom secret key
+/// $secretKey = [byte[]]@(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20)
+/// Set-YubiKeyOTP -Slot LongPress -HOTP -SecretKey $secretKey
+/// 
+/// .EXAMPLE
+/// # Configure HOTP with base32 encoded secret and carriage return
+/// Set-YubiKeyOTP -Slot ShortPress -HOTP -Base32Secret "QRFJ7DTIVASL3PNYXWFIQAQN5RKUJD4U" -AppendCarriageReturn
+/// </summary>
+/// 
+
+using System.Management.Automation;
 using System.Runtime.InteropServices;
 using System.Security;
 using powershellYK.OTP;
 using powershellYK.support.validators;
 using powershellYK.support.transform;
+using powershellYK.support;
 using Yubico.Core.Buffers;
 using Yubico.Core.Devices.Hid;
 using Yubico.YubiKey;
@@ -12,47 +62,92 @@ using Yubico.YubiKey.Otp.Operations;
 
 namespace powershellYK.Cmdlets.OTP
 {
+
     [Cmdlet(VerbsCommon.Set, "YubiKeyOTP", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.High)]
     public class SetYubikeyOTPCommand : PSCmdlet
     {
+        /// Specifies which YubiKey OTP slot to configure (ShortPress or LongPress)
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Yubikey OTP Slot")]
         public Slot Slot { get; set; }
+
+        /// Configures the slot for Yubico OTP mode
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Allows configuration with all defaults", ParameterSetName = "Yubico OTP")]
         public SwitchParameter YubicoOTP { get; set; }
+
+        /// Configures the slot for Static Password mode
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Allows configuration with all defaults", ParameterSetName = "Static Password")]
         public SwitchParameter StaticPassword { get; set; }
+
+        /// Configures the slot for Static Generated Password mode
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Allows configuration with all defaults", ParameterSetName = "Static Generated Password")]
         public SwitchParameter StaticGeneratedPassword { get; set; }
+
+        /// Configures the slot for Challenge-Response mode
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Allows for Challenge-Response configuration with all defaults", ParameterSetName = "ChallengeResponse")]
         public SwitchParameter ChallengeResponse { get; set; }
+
+        /// Public ID for Yubico OTP mode. If not specified, uses YubiKey serial number
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Sets the Public ID, defaults to YubiKey serial number", ParameterSetName = "Yubico OTP")]
         public byte[]? PublicID { get; set; }
+
+        /// Private ID for Yubico OTP mode. If not specified, generates random 6 bytes
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Sets the Private ID, defaults to random 6 bytes", ParameterSetName = "Yubico OTP")]
         public byte[]? PrivateID { get; set; }
+
+        /// <summary>
+        /// Secret key for OTP modes. For Yubico OTP: 16 bytes, for Challenge-Response: 20 bytes, for HOTP: 20 bytes
+        /// </summary>
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Sets the Secret Key, defaults to random 16 bytes", ParameterSetName = "Yubico OTP")]
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Sets the Secret Key, defaults to random 20 bytes", ParameterSetName = "ChallengeResponse")]
+        [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Sets the Secret Key, defaults to random 20 bytes", ParameterSetName = "HOTP")]
         public byte[]? SecretKey { get; set; }
+
+        /// Flag to upload Yubico OTP configuration to YubiCloud
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Upload to YubiCloud", ParameterSetName = "Yubico OTP")]
         public SwitchParameter Upload { get; set; }
+
+        /// Static password to be configured (1-38 characters)
         [ValidateYubikeyPassword(1, 38)]
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Static password that will be set", ParameterSetName = "Static Password")]
         public SecureString? Password { get; set; }
+
+        /// Length of the generated static password (1-38 characters)
         [ValidateRange(1, 38)]
         [Parameter(Mandatory = true, ValueFromPipeline = false, HelpMessage = "Static password that will be set", ParameterSetName = "Static Generated Password")]
         public int PasswordLength { get; set; }
+
+        /// Keyboard layout to use for static passwords
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Keyboard layout to be used", ParameterSetName = "Static Password")]
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Keyboard layout to be used", ParameterSetName = "Static Generated Password")]
         public KeyboardLayout KeyboardLayout { get; set; } = KeyboardLayout.ModHex;
+
+        /// <summary>
+        /// Flag to append carriage return (Enter) to static passwords
+        /// </summary>
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Append carriage return (Enter)", ParameterSetName = "Static Password")]
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Append carriage return (Enter)", ParameterSetName = "Static Generated Password")]
+        [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Append carriage return (Enter)", ParameterSetName = "HOTP")]
         public SwitchParameter AppendCarriageReturn { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Algorithm for Challange-Response", ParameterSetName = "ChallengeResponse")]
+        /// Configures the slot for HMAC-based One-Time Password (HOTP) mode
+        [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Allows configuration of HOTP mode", ParameterSetName = "HOTP")]
+        public SwitchParameter HOTP { get; set; }
+
+        /// Algorithm to use for Challenge-Response mode
+        [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Algorithm for Challenge-Response", ParameterSetName = "ChallengeResponse")]
         public ChallengeResponseAlgorithm Algorithm { get; set; } = ChallengeResponseAlgorithm.HmacSha1;
 
+        /// Flag to require touch for Challenge-Response operations
         [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Require Touch", ParameterSetName = "ChallengeResponse")]
         public SwitchParameter RequireTouch { get; set; }
 
+        /// <summary>
+        /// Base32 encoded secret key for HOTP mode
+        /// </summary>
+        [Parameter(Mandatory = false, ValueFromPipeline = false, HelpMessage = "Base32 encoded secret key for HOTP", ParameterSetName = "HOTP")]
+        public string? Base32Secret { get; set; }
+
+        /// Initializes the cmdlet by ensuring a YubiKey is connected
         protected override void BeginProcessing()
         {
             if (YubiKeyModule._yubikey is null)
@@ -70,21 +165,29 @@ namespace powershellYK.Cmdlets.OTP
                 }
             }
         }
-        protected override void ProcessRecord()
+
+
+        /// Main processing method that configures the YubiKey OTP settings based on the selected mode
+          protected override void ProcessRecord()
         {
             using (var otpSession = new OtpSession((YubiKeyDevice)YubiKeyModule._yubikey!))
             {
                 WriteDebug($"Working with {ParameterSetName}");
-                if ((Slot == Yubico.YubiKey.Otp.Slot.ShortPress && !otpSession.IsShortPressConfigured) || (Slot == Yubico.YubiKey.Otp.Slot.LongPress && !otpSession.IsLongPressConfigured) || ShouldProcess($"Yubikey OTP {Slot}", "Set"))
+                if ((Slot == Yubico.YubiKey.Otp.Slot.ShortPress && !otpSession.IsShortPressConfigured) || 
+                    (Slot == Yubico.YubiKey.Otp.Slot.LongPress && !otpSession.IsLongPressConfigured) || 
+                    ShouldProcess($"Yubikey OTP {Slot}", "Set"))
                 {
                     switch (ParameterSetName)
                     {
                         case "Yubico OTP":
+                            // Configure Yubico OTP mode
                             Memory<byte> _publicID = new Memory<byte>(new byte[6]);
                             Memory<byte> _privateID = new Memory<byte>(new byte[6]);
                             Memory<byte> _secretKey = new Memory<byte>(new byte[16]);
                             ConfigureYubicoOtp configureyubicoOtp = otpSession.ConfigureYubicoOtp(Slot);
                             int? serial = YubiKeyModule._yubikey!.SerialNumber;
+
+                            // Handle Public ID configuration
                             if (PublicID is null)
                             {
                                 configureyubicoOtp = configureyubicoOtp.UseSerialNumberAsPublicId(_publicID);
@@ -94,6 +197,8 @@ namespace powershellYK.Cmdlets.OTP
                                 _publicID = PublicID;
                                 configureyubicoOtp = configureyubicoOtp.UsePublicId(PublicID);
                             }
+
+                            // Handle Private ID configuration
                             if (PrivateID is null)
                             {
                                 configureyubicoOtp = configureyubicoOtp.GeneratePrivateId(_privateID);
@@ -103,6 +208,8 @@ namespace powershellYK.Cmdlets.OTP
                                 _privateID = PrivateID;
                                 configureyubicoOtp = configureyubicoOtp.UsePublicId(PrivateID);
                             }
+
+                            // Handle Secret Key configuration
                             if (SecretKey is null)
                             {
                                 configureyubicoOtp = configureyubicoOtp.GenerateKey(_secretKey);
@@ -112,12 +219,17 @@ namespace powershellYK.Cmdlets.OTP
                                 _secretKey = SecretKey;
                                 configureyubicoOtp = configureyubicoOtp.UseKey(SecretKey);
                             }
+
                             configureyubicoOtp.Execute();
+
+                            // Return configuration if any defaults were used
                             if (PublicID is null || PrivateID is null || SecretKey is null)
                             {
                                 YubicoOTP retur = new YubicoOTP(serial, _publicID.ToArray(), _privateID.ToArray(), _secretKey.ToArray(), "");
                                 WriteObject(retur);
                             }
+
+                            // Handle YubiCloud upload
                             if (Upload.IsPresent)
                             {
                                 // https://github.com/Yubico/yubikey-manager/blob/fbdae2bc12ba0451bcfc62372bc9191c10ecad0c/ykman/otp.py#L95
@@ -128,6 +240,7 @@ namespace powershellYK.Cmdlets.OTP
                             break;
 
                         case "Static Password":
+                            // Configure static password mode
                             ConfigureStaticPassword staticpassword = otpSession.ConfigureStaticPassword(Slot);
                             staticpassword = staticpassword.WithKeyboard(KeyboardLayout);
                             staticpassword = staticpassword.SetPassword((Marshal.PtrToStringUni(Marshal.SecureStringToGlobalAllocUnicode(Password!))!).AsMemory());
@@ -137,7 +250,9 @@ namespace powershellYK.Cmdlets.OTP
                             }
                             staticpassword.Execute();
                             break;
+
                         case "Static Generated Password":
+                            // Configure static generated password mode
                             ConfigureStaticPassword staticgenpassword = otpSession.ConfigureStaticPassword(Slot);
                             Memory<char> generatedPassword = new Memory<char>(new char[PasswordLength]);
                             staticgenpassword = staticgenpassword.WithKeyboard(KeyboardLayout);
@@ -148,9 +263,13 @@ namespace powershellYK.Cmdlets.OTP
                             }
                             staticgenpassword.Execute();
                             break;
+
                         case "ChallengeResponse":
+                            // Configure challenge-response mode
                             Memory<byte> _CRsecretKey = new Memory<byte>(new byte[20]);
                             ConfigureChallengeResponse configureCR = otpSession.ConfigureChallengeResponse(Slot);
+                            
+                            // Handle Secret Key configuration
                             if (SecretKey is null)
                             {
                                 configureCR = configureCR.GenerateKey(_CRsecretKey);
@@ -160,10 +279,14 @@ namespace powershellYK.Cmdlets.OTP
                                 _CRsecretKey = SecretKey;
                                 configureCR = configureCR.UseKey(SecretKey);
                             }
+
+                            // Configure touch requirement
                             if (RequireTouch.IsPresent)
                             {
                                 configureCR = configureCR.UseButton();
                             }
+
+                            // Configure algorithm
                             if (Algorithm == ChallengeResponseAlgorithm.HmacSha1)
                             {
                                 configureCR = configureCR.UseHmacSha1();
@@ -172,17 +295,55 @@ namespace powershellYK.Cmdlets.OTP
                             {
                                 configureCR = configureCR.UseYubiOtp();
                             }
+
                             configureCR.Execute();
+
+                            // Return configuration if default key was used
                             if (SecretKey is null)
                             {
                                 ChallangeResponse retur = new ChallangeResponse(_CRsecretKey.ToArray());
                                 WriteObject(retur);
                             }
                             break;
+
+                        case "HOTP":
+                            // Configure HOTP mode
+                            Memory<byte> _HOTPsecretKey = new Memory<byte>(new byte[20]);
+                            ConfigureHotp configureHOTP = otpSession.ConfigureHotp(Slot);
+                            
+                            // Handle Secret Key configuration
+                            if (Base32Secret != null)
+                            {
+                                _HOTPsecretKey = powershellYK.support.Base32.Decode(Base32Secret);
+                                configureHOTP = configureHOTP.UseKey(_HOTPsecretKey);
+                            }
+                            else if (SecretKey is null)
+                            {
+                                configureHOTP = configureHOTP.GenerateKey(_HOTPsecretKey);
+                            }
+                            else
+                            {
+                                _HOTPsecretKey = SecretKey;
+                                configureHOTP = configureHOTP.UseKey(SecretKey);
+                            }
+
+                            // Configure carriage return if requested
+                            if (AppendCarriageReturn.IsPresent)
+                            {
+                                configureHOTP = configureHOTP.AppendCarriageReturn();
+                            }
+
+                            configureHOTP.Execute();
+
+                            // Return both raw and Base32 representations of the key
+                            WriteObject(new { 
+                                SecretKey = _HOTPsecretKey.ToArray(),
+                                Base32Secret = powershellYK.support.Base32.Encode(_HOTPsecretKey.ToArray())
+                            });
+                            break;
                     }
                 }
             }
         }
-
     }
 }

--- a/Module/Cmdlets/OTP/SetYubikeyOTP.cs
+++ b/Module/Cmdlets/OTP/SetYubikeyOTP.cs
@@ -168,13 +168,13 @@ namespace powershellYK.Cmdlets.OTP
 
 
         /// Main processing method that configures the YubiKey OTP settings based on the selected mode
-          protected override void ProcessRecord()
+        protected override void ProcessRecord()
         {
             using (var otpSession = new OtpSession((YubiKeyDevice)YubiKeyModule._yubikey!))
             {
                 WriteDebug($"Working with {ParameterSetName}");
-                if ((Slot == Yubico.YubiKey.Otp.Slot.ShortPress && !otpSession.IsShortPressConfigured) || 
-                    (Slot == Yubico.YubiKey.Otp.Slot.LongPress && !otpSession.IsLongPressConfigured) || 
+                if ((Slot == Yubico.YubiKey.Otp.Slot.ShortPress && !otpSession.IsShortPressConfigured) ||
+                    (Slot == Yubico.YubiKey.Otp.Slot.LongPress && !otpSession.IsLongPressConfigured) ||
                     ShouldProcess($"Yubikey OTP {Slot}", "Set"))
                 {
                     switch (ParameterSetName)
@@ -268,7 +268,7 @@ namespace powershellYK.Cmdlets.OTP
                             // Configure challenge-response mode
                             Memory<byte> _CRsecretKey = new Memory<byte>(new byte[20]);
                             ConfigureChallengeResponse configureCR = otpSession.ConfigureChallengeResponse(Slot);
-                            
+
                             // Handle Secret Key configuration
                             if (SecretKey is null)
                             {
@@ -310,7 +310,7 @@ namespace powershellYK.Cmdlets.OTP
                             // Configure HOTP mode
                             Memory<byte> _HOTPsecretKey = new Memory<byte>(new byte[20]);
                             ConfigureHotp configureHOTP = otpSession.ConfigureHotp(Slot);
-                            
+
                             // Handle Secret Key configuration
                             if (Base32Secret != null)
                             {
@@ -336,7 +336,8 @@ namespace powershellYK.Cmdlets.OTP
                             configureHOTP.Execute();
 
                             // Return both raw and Base32 representations of the key
-                            WriteObject(new { 
+                            WriteObject(new
+                            {
                                 SecretKey = _HOTPsecretKey.ToArray(),
                                 Base32Secret = powershellYK.support.Base32.Encode(_HOTPsecretKey.ToArray())
                             });

--- a/Module/support/Base32.cs
+++ b/Module/support/Base32.cs
@@ -1,0 +1,93 @@
+/// <summary>
+/// Utility class for Base32 encoding and decoding using the standard alphabet (A-Z2-7)
+/// </summary>
+
+using System;
+using System.Text;
+
+namespace powershellYK.support
+{
+
+    public static class Base32
+    {
+        private const string Base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        private const int BitsPerChar = 5;
+        private const int BitsPerByte = 8;
+
+        /// Encodes a byte array to a Base32 string
+        public static string Encode(byte[] data)
+        {
+            if (data == null)
+                throw new ArgumentNullException(nameof(data));
+
+            if (data.Length == 0)
+                return string.Empty;
+
+            // Calculate the number of characters needed
+            int charCount = (int)Math.Ceiling(data.Length * BitsPerByte / (double)BitsPerChar);
+            var result = new StringBuilder(charCount);
+
+            int buffer = 0;
+            int bufferBits = 0;
+
+            foreach (byte b in data)
+            {
+                buffer = (buffer << BitsPerByte) | b;
+                bufferBits += BitsPerByte;
+
+                while (bufferBits >= BitsPerChar)
+                {
+                    bufferBits -= BitsPerChar;
+                    int index = (buffer >> bufferBits) & 0x1F;
+                    result.Append(Base32Alphabet[index]);
+                }
+            }
+
+            // Handle remaining bits
+            if (bufferBits > 0)
+            {
+                buffer <<= (BitsPerChar - bufferBits);
+                int index = buffer & 0x1F;
+                result.Append(Base32Alphabet[index]);
+            }
+
+            return result.ToString();
+        }
+
+        /// Decodes a Base32 string to a byte array
+        public static byte[] Decode(string base32String)
+        {
+            if (string.IsNullOrEmpty(base32String))
+                return Array.Empty<byte>();
+
+            // Remove any padding characters and convert to uppercase
+            base32String = base32String.TrimEnd('=').ToUpper();
+
+            // Calculate the number of bytes needed
+            int byteCount = (int)Math.Floor(base32String.Length * BitsPerChar / (double)BitsPerByte);
+            var result = new byte[byteCount];
+
+            int buffer = 0;
+            int bufferBits = 0;
+            int byteIndex = 0;
+
+            foreach (char c in base32String)
+            {
+                int value = Base32Alphabet.IndexOf(c);
+                if (value == -1)
+                    throw new ArgumentException($"Invalid Base32 character: {c}");
+
+                buffer = (buffer << BitsPerChar) | value;
+                bufferBits += BitsPerChar;
+
+                while (bufferBits >= BitsPerByte)
+                {
+                    bufferBits -= BitsPerByte;
+                    result[byteIndex++] = (byte)((buffer >> bufferBits) & 0xFF);
+                }
+            }
+
+            return result;
+        }
+    }
+} 

--- a/Module/support/Base32.cs
+++ b/Module/support/Base32.cs
@@ -90,4 +90,4 @@ namespace powershellYK.support
             return result;
         }
     }
-} 
+}

--- a/Pester/420-OTP-HOTP.tests.ps1
+++ b/Pester/420-OTP-HOTP.tests.ps1
@@ -1,0 +1,13 @@
+Describe "OTP HOTP Tests" -Tag "OTP",'OTP-HOTP'  {
+    It -Name "Setting should not throw" -Test {
+        {$return = Set-YubiKeyOTP -Slot ShortPress -HOTP -SecretKey ([byte[]]@(2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)) -Confirm:$false} | Should -Not -Throw
+    }
+    It -Name "Verify that it sets it correctly" -Test {
+        $return = Set-YubiKeyOTP -Slot ShortPress -HOTP -SecretKey ([byte[]]@(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20)) -Confirm:$false
+	$return.Base32Secret | Should -Be "AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYU"
+    }
+    It -Name "Verify that it sets it correctly from Base32" -Test {
+        $return = Set-YubiKeyOTP -Slot ShortPress -HOTP -Base32Secret 'QRFJ7DTIVASL3PNYXWFIQAQN5RKUJD4U' -Confirm:$false
+	$return.SecretKey | Should -Be @(0x84, 0x4a, 0x9f, 0x8e, 0x68, 0xa8, 0x24, 0xbd, 0xbd, 0xb8, 0xbd, 0x8a, 0x88, 0x02, 0x0d, 0xec, 0x55, 0x44, 0x8f, 0x94)
+    }
+}


### PR DESCRIPTION
#### Extended `SetYubiKeyOTP.cs` to handle **HOTP** on slot 1 and 2
Program an HOTP secret on short press or long press slot with either a randomized key or an external key in either byte or Base32 format. Return programmed key as both format for cross-reference or population of seed file.

#### Added Base32 helper class for OATH secrets input and output.
Converts secret key from byte to Base32 and Base32 to byte format. This is in order to better support using a 3rd party AAA server for OTP validation. 

### Test cases
Secret (Base32): QRFJ7DTIVASL3PNYXWFIQAQN5RKUJD4U

HOTPs (10 first):
| Counter | HOTP Code |
| ------- | --------- |
| 0       | `984694`  |
| 1       | `925675`  |
| 2       | `214232`  |
| 3       | `317736`  |
| 4       | `124869`  |
| 5       | `048798`  |
| 6       | `637317`  |
| 7       | `988135`  |
| 8       | `382233`  |
| 9       | `653804`  |