### PR TITLE
Updates to YubiKeyInformation type

### DIFF
--- a/Module/Cmdlets/Yubikey/FindYubikey.cs
+++ b/Module/Cmdlets/Yubikey/FindYubikey.cs
@@ -16,6 +16,7 @@
 /// </summary>
 
 // Imports
+using powershellYK.YubiKey;
 using System.Management.Automation;           // Windows PowerShell namespace.
 using Yubico.YubiKey;
 
@@ -57,7 +58,7 @@ namespace powershellYK.Cmdlets.Yubikey
                 // Return found YubiKeys
                 foreach (var yubiKey in yubiKeys)
                 {
-                    WriteObject((YubiKeyDevice)yubiKey);
+                    WriteObject(new YubikeyInformation(yubiKey: (YubiKeyDevice)yubiKey));
                 }
 
                 // Handle case when no YubiKeys are found

--- a/Module/Cmdlets/Yubikey/GetYubikey.cs
+++ b/Module/Cmdlets/Yubikey/GetYubikey.cs
@@ -55,7 +55,7 @@ namespace powershellYK.Cmdlets.Yubikey
                 try
                 {
                     // Get and return YubiKey information
-                    WriteObject(new YubikeyInformation(yubiKey: (YubiKeyDevice)YubiKeyDevice.FindAll().Where(yk => yk.SerialNumber == YubiKeyModule._yubikey!.SerialNumber).First()));
+                    WriteObject(new YubikeyInformation(yubiKey: YubiKeyModule._yubikey));
                 }
                 catch (System.InvalidOperationException e)
                 {

--- a/Module/types/YubiKeyInformation.cs
+++ b/Module/types/YubiKeyInformation.cs
@@ -25,6 +25,7 @@ using Yubico.YubiKey.Fido2.PinProtocols;
 using Yubico.YubiKey.Fido2.Cose;
 using powershellYK.support;
 using Yubico.YubiKey;
+using powershellYK.PIV;
 
 namespace powershellYK.YubiKey
 {
@@ -110,5 +111,14 @@ namespace powershellYK.YubiKey
             this.YubiKeyDevice = yubiKey;
             this.PrettyName = PowershellYKText.FriendlyName(yubiKey);
         }
+
+        #region Operators
+
+        public static implicit operator YubiKeyDevice(YubikeyInformation info)
+        {
+            return info.YubiKeyDevice;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Change Find-YubiKey to return YubikeyInformation type
Change Get-YubiKey to simpler ways, Yubico SDK caches the issue that I wanted to work around, no need for complex code then Update YubikeyInformation to allow for transformed to YubiKeyDevice by casting.