### PR TITLE
Added cmdlet to generate psudo random challenge to support SSH keygen…

### DIFF
--- a/Module/Cmdlets/Other/NewChallenge.cs
+++ b/Module/Cmdlets/Other/NewChallenge.cs
@@ -17,34 +17,49 @@
 /// </summary>
 
 // Imports
+using powershellYK.support.transform;
+using powershellYK.support.validators;
+using System.IO;
 using System.Management.Automation;
 using System.Security.Cryptography;
 
 namespace powershellYK.Cmdlets.Other
 {
-    [Cmdlet(VerbsCommon.Get, "Challenge")]
-    public class GetChallengeCommand : Cmdlet
+    [Cmdlet(VerbsCommon.New, "Challenge")]
+    public class NewChallengeCommand : Cmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "Length of the challenge in bytes")]
         [ValidateRange(1, 4096)]
         public int Length { get; set; } = 128;
 
-        [Parameter(Mandatory = false, HelpMessage = "Path for the output file. Defaults to challenge.bin")]
-        public string? OutFile { get; set; }
+        [TransformPath]
+        [Parameter(Mandatory = true, HelpMessage = "Path for the output file.")]
+        public required System.IO.FileInfo OutFile { get; set; }
+
+        [Parameter(Mandatory = false, HelpMessage = "Force overwriting existing files.")]
+        public SwitchParameter Force { get; set; } = false;
 
         // Process the main cmdlet logic
         protected override void ProcessRecord()
         {
+            if (OutFile.Exists && !Force.IsPresent)
+            {
+                var ex = new IOException($"File already exists: {OutFile.FullName}");
+                ex.HResult = unchecked((int)0x80070050); // ERROR_FILE_EXISTS
+                throw ex;
+            }
+
             // Generate cryptographically secure random challenge bytes
             byte[] challenge = new byte[Length];
             RandomNumberGenerator.Fill(challenge);
 
             // Determine output path; default to challenge.bin when not specified
-            string path = string.IsNullOrEmpty(OutFile) ? "challenge.bin" : OutFile;
-            System.IO.File.WriteAllBytes(path, challenge);
-
+            using (var file = OutFile.OpenWrite())
+            {
+                file.Write(challenge);
+            }
             // Confirm completion to the user
-            WriteInformation($"Challenge of length {Length} generated and written to file '{path}'.", new[] { "Challenge", "Info" });
+            WriteInformation($"Challenge of length {Length} generated and written to file '{OutFile.FullName}'.", new[] { "Challenge", "Info" });
         }
     }
 }

--- a/Module/powershellYK.psd1
+++ b/Module/powershellYK.psd1
@@ -131,7 +131,7 @@ CmdletsToExport = @(
  'Remove-YubiKeyBIOFingerprint',
  'Rename-YubiKeyBIOFingerprint',
  'ConvertTo-AltSecurity',
- 'Get-Challenge',
+ 'New-Challenge',
  'Enable-PowershellYKSDKLogging',
  'Get-PowershellYKInfo'
 )

--- a/Pester/991-Get-Challenge.tests.ps1
+++ b/Pester/991-Get-Challenge.tests.ps1
@@ -1,62 +1,71 @@
-Describe "Get-Challenge" -Tag "Without-YubiKey" {
-    It -Name "Creates file with default length (128 bytes)" -Test {
-        $outFile = Join-Path $env:TEMP "pester_challenge_$(Get-Random).bin"
-        Get-Challenge -OutFile $outFile
-        (Test-Path $outFile) | Should Be $true
-        (Get-Item $outFile).Length | Should Be 128
+Describe "New-Challenge" -Tag "Without-YubiKey" {
+
+    BeforeEach {
+        $outFile = [System.IO.Path]::GetTempFileName()
         Remove-Item $outFile -Force -ErrorAction SilentlyContinue
+    }
+
+    AfterEach {
+        Remove-Item $outFile -Force -ErrorAction SilentlyContinue
+    }
+
+    It -Name "Creates file with default length (128 bytes)" -Test {
+        New-Challenge -OutFile $outFile
+        (Test-Path $outFile) | Should -Be $true
+        (Get-Item $outFile).Length | Should -Be 128
     }
 
     It -Name "Creates file with -Length 256" -Test {
-        $outFile = Join-Path $env:TEMP "pester_challenge_$(Get-Random).bin"
-        Get-Challenge -Length 256 -OutFile $outFile
-        (Get-Item $outFile).Length | Should Be 256
-        Remove-Item $outFile -Force -ErrorAction SilentlyContinue
+        New-Challenge -Length 256 -OutFile $outFile
+        (Get-Item $outFile).Length | Should -Be 256
     }
 
     It -Name "Creates file with -Length 1 (min boundary)" -Test {
-        $outFile = Join-Path $env:TEMP "pester_challenge_$(Get-Random).bin"
-        Get-Challenge -Length 1 -OutFile $outFile
-        (Get-Item $outFile).Length | Should Be 1
-        Remove-Item $outFile -Force -ErrorAction SilentlyContinue
+        New-Challenge -Length 1 -OutFile $outFile
+        (Get-Item $outFile).Length | Should -Be 1
     }
 
     It -Name "Creates file with -Length 4096 (max boundary)" -Test {
-        $outFile = Join-Path $env:TEMP "pester_challenge_$(Get-Random).bin"
-        Get-Challenge -Length 4096 -OutFile $outFile
-        (Get-Item $outFile).Length | Should Be 4096
-        Remove-Item $outFile -Force -ErrorAction SilentlyContinue
+        New-Challenge -Length 4096 -OutFile $outFile
+        (Get-Item $outFile).Length | Should -Be 4096
     }
 
     It -Name "Generates different content on each call" -Test {
-        $outFile = Join-Path $env:TEMP "pester_challenge_$(Get-Random).bin"
-        Get-Challenge -Length 64 -OutFile $outFile
+        Write-Verbose "$outFile"
+        New-Challenge -Length 64 -OutFile $outFile
         $first = [System.IO.File]::ReadAllBytes($outFile)
-        Get-Challenge -Length 64 -OutFile $outFile
+        New-Challenge -Length 64 -OutFile $outFile -Force
         $second = [System.IO.File]::ReadAllBytes($outFile)
-        ([System.BitConverter]::ToString($first) -ne [System.BitConverter]::ToString($second)) | Should Be $true
+        ([System.BitConverter]::ToString($first) -ne [System.BitConverter]::ToString($second)) | Should -Be $true
+    }
+
+    It -Name "Overwrites existing file using -Force" -Test {
+        [System.IO.File]::WriteAllBytes($outFile, [byte[]]@(1, 2, 3))
+        New-Challenge -Length 16 -OutFile $outFile -Force
+        (Get-Item $outFile).Length | Should -Be 16
+    }
+
+}
+
+Describe "New-Challenge Errors" -Tag "Without-YubiKey" {
+    BeforeAll {
+        $outFile = [System.IO.Path]::GetTempFileName()
+    }
+
+    AfterAll {
         Remove-Item $outFile -Force -ErrorAction SilentlyContinue
     }
 
-    It -Name "Overwrites existing file" -Test {
-        $overwritePath = Join-Path $env:TEMP "pester_overwrite_$(Get-Random).bin"
-        [System.IO.File]::WriteAllBytes($overwritePath, [byte[]]@(1, 2, 3))
-        Get-Challenge -Length 16 -OutFile $overwritePath
-        (Get-Item $overwritePath).Length | Should Be 16
-        Remove-Item $overwritePath -Force -ErrorAction SilentlyContinue
-    }
-}
-
-Describe "Get-Challenge Errors" -Tag "Without-YubiKey" {
     It -Name "Length 0 throws (below range)" -Test {
-        $threw = $false
-        try { Get-Challenge -Length 0 -OutFile (Join-Path $env:TEMP "pester_challenge_err.bin") } catch { $threw = $true }
-        $threw | Should Be $true
+        { New-Challenge -Length 0 -OutFile $outFile } | Should -Throw
     }
 
     It -Name "Length 4097 throws (above range)" -Test {
-        $threw = $false
-        try { Get-Challenge -Length 4097 -OutFile (Join-Path $env:TEMP "pester_challenge_err.bin") } catch { $threw = $true }
-        $threw | Should Be $true
+        { New-Challenge -Length 4097 -OutFile $outFile } | Should -Throw
     }
+
+    It -Name "Overwrites existing file" -Test {
+        { New-Challenge -Length 16 -OutFile $outFile } | Should -Throw
+    }
+
 }


### PR DESCRIPTION
Added cmdlet to generate pseudo random challenge to support SSH keygen FIDO attestation.

The cmdlet, invoked by `Get-Challenge` generates a 128 bit binary challenge output as "challenge.bin".

This challenge can then be used in producing an attestation object for Open SSH with FIDO2 as per:

`ssh-keygen -t ed25519-sk -O resident -O verify-required -O user=bob -C bob@swjm.blog -O challenge=challenge.bin -O write-attestation=attestation.bin`