### PR TITLE
Add NFC ID (decimal and hex) to Get-YubiKey output

### DIFF
--- a/Module/Cmdlets/Yubikey/GetYubikey.cs
+++ b/Module/Cmdlets/Yubikey/GetYubikey.cs
@@ -6,6 +6,10 @@
 /// .EXAMPLE
 /// Get-YubiKey
 /// Returns information about the currently connected YubiKey
+/// 
+/// .EXAMPLE
+/// Get-YubiKey | Select-Object SerialNumber, NfcIdDec, NfcIdHex
+/// Returns information about select attributes of the YubiKey: serial number, NFC ID (decimal) and NFC ID (hex)
 /// </summary>
 
 using System.Management.Automation;           // Windows PowerShell namespace.

--- a/Module/support/Converter.cs
+++ b/Module/support/Converter.cs
@@ -9,6 +9,17 @@
 /// .EXAMPLE
 /// $bytes = [byte[]]@(0x1A, 0x2B, 0x3C, 0x4D)
 /// $hexString = [powershellYK.support.Converter]::ByteArrayToString($bytes)
+/// 
+/// .EXAMPLE
+/// $uid = [powershellYK.support.Converter]::SerialToNfcUid(12345678)
+/// $hex = [powershellYK.support.Converter]::ByteArrayToString($uid)
+/// Returns NFC ID in hex: "274E61BC00614E"
+/// 
+/// .EXAMPLE
+/// $uid = [powershellYK.support.Converter]::SerialToNfcUid(12345678)
+/// $dec = [powershellYK.support.Converter]::NfcUidToDecimal($uid)
+/// Returns NFC ID in decimal: 11161651036004942
+/// 
 /// </summary>
 
 // Imports
@@ -94,6 +105,33 @@ namespace powershellYK.support
                 base64 += new string('=', paddingCount);
             }
             return base64;
+        }
+
+        // Derive the 7-byte NFC UID from a YubiKey serial number
+        public static byte[] SerialToNfcUid(uint serial)
+        {
+            byte b0 = (byte)(serial >> 24);
+            byte b1 = (byte)(serial >> 16);
+            byte b2 = (byte)(serial >> 8);
+            byte b3 = (byte)serial;
+
+            return new byte[] { 0x27, b3, b2, b1, b0, b2, b3 };
+        }
+
+        // Derive the decimal representation of a 7-byte NFC UID
+        public static ulong NfcUidToDecimal(byte[] uid)
+        {
+            if (uid.Length != 7)
+            {
+                throw new ArgumentException("NFC UID must be 7 bytes long", nameof(uid));
+            }
+
+            ulong value = 0;
+            for (int i = 0; i < uid.Length; i++)
+            {
+                value = (value << 8) | uid[i];
+            }
+            return value;
         }
 
         // Convert YubiKey public key to .NET asymmetric algorithm

--- a/Module/types/YubiKeyInformation.cs
+++ b/Module/types/YubiKeyInformation.cs
@@ -72,6 +72,28 @@ namespace powershellYK.YubiKey
         // YubiKey serial number
         public int? SerialNumber { get { return YubiKeyDevice.SerialNumber; } }
 
+        // NFC UID as decimal
+        public string? NfcIdDec
+        {
+            get
+            {
+                if (SerialNumber is null) return null;
+                byte[] uid = Converter.SerialToNfcUid((uint)SerialNumber.Value);
+                return Converter.NfcUidToDecimal(uid).ToString();
+            }
+        }
+
+        // NFC UID as hex
+        public string? NfcIdHex
+        {
+            get
+            {
+                if (SerialNumber is null) return null;
+                byte[] uid = Converter.SerialToNfcUid((uint)SerialNumber.Value);
+                return Converter.ByteArrayToString(uid);
+            }
+        }
+
         // FIPS series status
         public bool IsFipsSeries { get { return YubiKeyDevice.IsFipsSeries; } }
 


### PR DESCRIPTION
## Add NFC ID (decimal and hex) to Get-YubiKey output

Add support for exposing the YubiKey NFC UID in both decimal and hexadecimal formats via `Get-YubiKey` in order to support / simplify PACS integration.

Derive the 7-byte NFC UID from the YubiKey serial number and expose it as two new properties on `YubikeyInformation`:
- `NfcIdDec`
- `NfcIdHex`

**Goal:** Improve usability by making the NFC identifier easily accessible for scenarios such as access control, and integration with NFC-based systems.

### Details
- Derive NFC UID from the YubiKey serial number using existing helpers:
  - `Converter.SerialToNfcUid`
  - `NfcUidToDecimal`
  - `ByteArrayToString`  
- Expose computed values via new `YubikeyInformation` properties:
  - `NfcIdDec` (decimal representation)
  - `NfcIdHex` (hexadecimal representation)