### PR TITLE
Update System.Management.Automation for all dotnet

### DIFF
--- a/Module/Cmdlets/FIDO2/ConfirmYubiKeyFIDO2Attestation.cs
+++ b/Module/Cmdlets/FIDO2/ConfirmYubiKeyFIDO2Attestation.cs
@@ -170,7 +170,11 @@ namespace powershellYK.Cmdlets.Fido
 
             try
             {
+#if NET9_0_OR_GREATER
+                return X509CertificateLoader.LoadCertificate(certDer);
+#else
                 return new X509Certificate2(certDer);
+#endif
             }
             catch
             {

--- a/Module/powershellYK.csproj
+++ b/Module/powershellYK.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <AssemblyVersion>0.0.18.0</AssemblyVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -54,16 +54,22 @@
     <PackageReference Include="Yubico.YubiKey" Version="1.15.2" />
   </ItemGroup>-->
 
-  <!-- PowerShell 7+ support -->
+  <!-- PowerShell 7.4 support -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.4.11" />
-    <PackageReference Include="Yubico.YubiKey" Version="1.15.2" />
+    <PackageReference Include="System.Management.Automation" Version="7.4.18" />
+    <PackageReference Include="Yubico.YubiKey" Version="1.17.1" />
   </ItemGroup>
 
-  <!-- PowerShell 7+ support -->
+  <!-- PowerShell 7.5 support -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.4.11" />
-    <PackageReference Include="Yubico.YubiKey" Version="1.15.2" />
+    <PackageReference Include="System.Management.Automation" Version="7.5.9" />
+    <PackageReference Include="Yubico.YubiKey" Version="1.17.1" />
+  </ItemGroup>
+
+  <!-- PowerShell 7.6+ support -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="System.Management.Automation" Version="7.6.4" />
+    <PackageReference Include="Yubico.YubiKey" Version="1.17.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
update Yubico.YubiKey for all dotnet
fix deprecation warning in ConfirmYubiKeyFIDO2Attestation.cs

.NET 8 / .NET 9 goes EOL November 10, 2026
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
Prepare to move to .NET 10.