### PR TITLE
Add support for hmac-secret-mc for PRF-based encryption with YubiKey 5.8+

### DIFF
--- a/Docs/Commands/Export-YubiKeyFIDO2Blob.md
+++ b/Docs/Commands/Export-YubiKeyFIDO2Blob.md
@@ -28,6 +28,12 @@ Export-YubiKeyFIDO2Blob -CredentialId <CredentialID> -OutFile <FileInfo> [<Commo
 Export-YubiKeyFIDO2Blob -RelyingPartyID <string> -OutFile <FileInfo> [<CommonParameters>]
 ```
 
+### AutoLookup (Default)
+
+```
+Export-YubiKeyFIDO2Blob -OutFile <FileInfo> [<CommonParameters>]
+```
+
 ## ALIASES
 
 ## DESCRIPTION
@@ -78,6 +84,12 @@ DefaultValue: ''
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
+- Name: AutoLookup
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
 - Name: Export LargeBlob
   Position: Named
   IsRequired: true
@@ -139,5 +151,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[FIDO2 large blobs ("largeBlobs" option)](https://docs.yubico.com/yesdk/users-manual/application-fido2/large-blobs.html)
-
+- [FIDO2 large blobs ("largeBlobs" option)](https://docs.yubico.com/yesdk/users-manual/application-fido2/large-blobs.html)

--- a/Docs/Commands/Get-YubikeyFIDO2Credential.md
+++ b/Docs/Commands/Get-YubikeyFIDO2Credential.md
@@ -32,6 +32,12 @@ Get-YubiKeyFIDO2Credential -CredentialID <CredentialID> [<CommonParameters>]
 Get-YubiKeyFIDO2Credential -CredentialIdBase64Url <String> [<CommonParameters>]
 ```
 
+### List-RelyingPartyID
+
+```
+Get-YubiKeyFIDO2Credential -RelyingPartyID <string> [<CommonParameters>]
+```
+
 ## ALIASES
 
 ## DESCRIPTION
@@ -107,6 +113,29 @@ SupportsWildcards: false
 Aliases: []
 ParameterSets:
 - Name: List-CredentialID-Base64URL
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RelyingPartyID
+
+Filter credentials by relying party ID
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- RP
+- Origin
+ParameterSets:
+- Name: List-RelyingPartyID
   Position: Named
   IsRequired: true
   ValueFromPipeline: false

--- a/Docs/Commands/Import-YubiKeyFIDO2Blob.md
+++ b/Docs/Commands/Import-YubiKeyFIDO2Blob.md
@@ -19,20 +19,24 @@ Imports large blob to YubiKey FIDO2 by Credential ID or Relying Party ID (Origin
 ### Set LargeBlob
 
 ```
-Import-YubiKeyFIDO2Blob -LargeBlob <FileInfo> -CredentialId <CredentialID> [-Force]
+Import-YubiKeyFIDO2Blob -Path <FileInfo> -CredentialId <CredentialID> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### Set LargeBlob by RelyingPartyID
 
 ```
-Import-YubiKeyFIDO2Blob -LargeBlob <FileInfo> -RelyingPartyID <string> [-Force] [<CommonParameters>]
+Import-YubiKeyFIDO2Blob -Path <FileInfo> -RelyingPartyID <string> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### AutoCreate (Default)
+
+```
+Import-YubiKeyFIDO2Blob -Path <FileInfo> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## ALIASES
-
-This cmdlet has the following aliases,
-  {{Insert list of aliases}}
 
 ## DESCRIPTION
 
@@ -50,6 +54,28 @@ Touch the YubiKey...
 Imports the large blob from the specified file for the credential with the specified Relying Party ID (or display name, if unique) to the YubiKey.
 
 ## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
 
 ### -CredentialId
 
@@ -75,6 +101,7 @@ HelpMessage: ''
 ### -Force
 
 Overwrite existing large blob entry for this credential without prompting.
+Suppress confirmation prompts (credential creation and blob overwrite).
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -82,6 +109,12 @@ DefaultValue: ''
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
+- Name: AutoCreate
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
 - Name: Set LargeBlob
   Position: Named
   IsRequired: false
@@ -126,6 +159,41 @@ AcceptedValues: []
 HelpMessage: ''
 ```
 
+### -Path
+
+File to import as large blob
+
+```yaml
+Type: System.IO.FileInfo
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- LargeBlob
+- File
+ParameterSets:
+- Name: AutoCreate
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Set LargeBlob
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Set LargeBlob by RelyingPartyID
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
 ### -RelyingPartyID
 
 Relying party ID, or relying party display name if unique, to associate with the large blob.
@@ -141,6 +209,28 @@ ParameterSets:
 - Name: Set LargeBlob by RelyingPartyID
   Position: Named
   IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
   ValueFromPipeline: false
   ValueFromPipelineByPropertyName: false
   ValueFromRemainingArguments: false
@@ -170,4 +260,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[FIDO2 large blobs ("largeBlobs" option)](https://docs.yubico.com/yesdk/users-manual/application-fido2/large-blobs.html)
+- [FIDO2 large blobs ("largeBlobs" option)](https://docs.yubico.com/yesdk/users-manual/application-fido2/large-blobs.html)

--- a/Docs/Commands/Protect-YubiKeyFIDO2File.md
+++ b/Docs/Commands/Protect-YubiKeyFIDO2File.md
@@ -16,7 +16,14 @@ Encrypts a file using FIDO2 PRF (hmac-secret) extension on a YubiKey.
 
 ## SYNTAX
 
-### WithCredential (Default)
+### AutoCreate (Default)
+
+```
+Protect-YubiKeyFIDO2File -Path <FileInfo> [-OutFile <FileInfo>] [-Force] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### WithCredential
 
 ```
 Protect-YubiKeyFIDO2File -Path <FileInfo> -Credential <Credential> [-OutFile <FileInfo>] [-WhatIf]
@@ -48,27 +55,36 @@ Encrypts a file using FIDO2 PRF (hmac-secret) extension on a YubiKey.
 Uses HKDF-SHA256 for key derivation and AES-256-GCM for authenticated encryption.
 Requires a YubiKey with FIDO2 hmac-secret support and administrator privileges on Windows.
 
+When no credential or relying party is provided, a synthetic `prf-encryption` credential is created or reused. On firmware 5.8+ (`hmac-secret-mc`), that first-time AutoCreate completes in one touch: the PRF is returned during credential creation. Older firmware still enables `hmac-secret` at creation and then requests the PRF with a second `GetAssertions` call (two touches). Reusing an existing credential, passing `-Credential`, and decrypting with `Unprotect-YubiKeyFIDO2File` always use a single assertion.
+
 ## EXAMPLES
 
 ### Example 1
 
 ```powershell
-$cred = Get-YubiKeyFIDO2Credential | Where-Object { $_.RelyingParty.Id -eq "demo.yubico.com" }
-Protect-YubiKeyFIDO2 -Path .\secret.txt -Credential $cred
+Protect-YubiKeyFIDO2File -Path .\secret.txt -Force
 ```
-Encrypts secret.txt using the specified FIDO2 credential
+Encrypts secret.txt, automatically creating or reusing a `prf-encryption` credential. On firmware 5.8+ the first-time create+encrypt is a single touch.
 
 ### Example 2
 
 ```powershell
-Get-Item .\secret.txt | Protect-YubiKeyFIDO2 -Credential $cred
+$cred = Get-YubiKeyFIDO2Credential | Where-Object { $_.RelyingParty.Id -eq "demo.yubico.com" }
+Protect-YubiKeyFIDO2File -Path .\secret.txt -Credential $cred
 ```
-Encrypts a file via pipeline input
+Encrypts secret.txt using the specified FIDO2 credential
 
 ### Example 3
 
 ```powershell
-Protect-YubiKeyFIDO2 -Path .\secret.txt -RelyingPartyID "demo.yubico.com"
+Get-Item .\secret.txt | Protect-YubiKeyFIDO2File -Credential $cred
+```
+Encrypts a file via pipeline input
+
+### Example 4
+
+```powershell
+Protect-YubiKeyFIDO2File -Path .\secret.txt -RelyingPartyID "demo.yubico.com"
 ```
 Encrypts using the sole credential for that relying party (aliases -RP and -Origin).
 
@@ -130,6 +146,27 @@ ParameterSets:
 - Name: WithCredentialID
   Position: Named
   IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Force
+
+Suppress the confirmation prompt when auto-creating a `prf-encryption` credential.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: AutoCreate
+  Position: Named
+  IsRequired: false
   ValueFromPipeline: false
   ValueFromPipelineByPropertyName: false
   ValueFromRemainingArguments: false
@@ -257,6 +294,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 FIDO private keys are non-exportable and never leave the YubiKey. Decryption therefore depends entirely on continued access to the original YubiKey _and_ the specific credential used for encryption. If the YubiKey is lost, reset, or if the credential is removed, the encrypted data cannot be recovered.
+
+On firmware 5.8+ (`hmac-secret-mc`), first-time AutoCreate encryption requires one user interaction. Older firmware requires two (create credential, then assert). Decrypt and encrypt-with-existing-credential always require one assertion.
 
 ## RELATED LINKS
 

--- a/Docs/Commands/Protect-YubiKeyFIDO2File.md
+++ b/Docs/Commands/Protect-YubiKeyFIDO2File.md
@@ -12,42 +12,39 @@ title: Protect-YubiKeyFIDO2File
 
 ## SYNOPSIS
 
-Encrypts a file using FIDO2 PRF (hmac-secret) extension on a YubiKey.
+Encrypts a file using FIDO2 PRF (hmac-secret / hmac-secret-mc) extension on a YubiKey.
 
 ## SYNTAX
 
 ### AutoCreate (Default)
 
 ```
-Protect-YubiKeyFIDO2File -Path <FileInfo> [-OutFile <FileInfo>] [-Force] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Protect-YubiKeyFIDO2File -Path <FileInfo> [-OutFile <FileInfo>] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### WithCredential
 
 ```
-Protect-YubiKeyFIDO2File -Path <FileInfo> -Credential <Credential> [-OutFile <FileInfo>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Protect-YubiKeyFIDO2File -Path <FileInfo> -Credential <Credential> [-OutFile <FileInfo>] [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### WithCredentialID
 
 ```
 Protect-YubiKeyFIDO2File -Path <FileInfo> -CredentialID <CredentialID> -RelyingPartyID <string>
- [-OutFile <FileInfo>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-OutFile <FileInfo>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByRelyingPartyID
 
 ```
-Protect-YubiKeyFIDO2File -Path <FileInfo> -RelyingPartyID <string> [-OutFile <FileInfo>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Protect-YubiKeyFIDO2File -Path <FileInfo> -RelyingPartyID <string> [-OutFile <FileInfo>] [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## ALIASES
-
-This cmdlet has the following aliases,
-  {{Insert list of aliases}}
 
 ## DESCRIPTION
 
@@ -157,6 +154,9 @@ HelpMessage: ''
 ### -Force
 
 Suppress the confirmation prompt when auto-creating a `prf-encryption` credential.
+Suppress the confirmation prompt when auto-creating a credential.
+Suppress the confirmation prompt when auto-creating a credential.
+Suppress the confirmation prompt when auto-creating a credential.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -164,7 +164,7 @@ DefaultValue: ''
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
-- Name: AutoCreate
+- Name: (All)
   Position: Named
   IsRequired: false
   ValueFromPipeline: false

--- a/Docs/Commands/Protect-YubiKeyFIDO2File.md
+++ b/Docs/Commands/Protect-YubiKeyFIDO2File.md
@@ -19,29 +19,29 @@ Encrypts a file using FIDO2 PRF (hmac-secret / hmac-secret-mc) extension on a Yu
 ### AutoCreate (Default)
 
 ```
-Protect-YubiKeyFIDO2File -Path <FileInfo> [-OutFile <FileInfo>] [-Force] [-WhatIf] [-Confirm]
+Protect-YubiKeyFIDO2File -Path <FileInfo> [-OutFile <FileInfo>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### WithCredential
 
 ```
-Protect-YubiKeyFIDO2File -Path <FileInfo> -Credential <Credential> [-OutFile <FileInfo>] [-Force]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Protect-YubiKeyFIDO2File -Path <FileInfo> -Credential <Credential> [-OutFile <FileInfo>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### WithCredentialID
 
 ```
 Protect-YubiKeyFIDO2File -Path <FileInfo> -CredentialID <CredentialID> -RelyingPartyID <string>
- [-OutFile <FileInfo>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-OutFile <FileInfo>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByRelyingPartyID
 
 ```
-Protect-YubiKeyFIDO2File -Path <FileInfo> -RelyingPartyID <string> [-OutFile <FileInfo>] [-Force]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Protect-YubiKeyFIDO2File -Path <FileInfo> -RelyingPartyID <string> [-OutFile <FileInfo>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## ALIASES
@@ -59,7 +59,7 @@ When no credential or relying party is provided, a synthetic `prf-encryption` cr
 ### Example 1
 
 ```powershell
-Protect-YubiKeyFIDO2File -Path .\secret.txt -Force
+Protect-YubiKeyFIDO2File -Path .\secret.txt -Confirm:$false
 ```
 Encrypts secret.txt, automatically creating or reusing a `prf-encryption` credential. On firmware 5.8+ the first-time create+encrypt is a single touch.
 
@@ -143,30 +143,6 @@ ParameterSets:
 - Name: WithCredentialID
   Position: Named
   IsRequired: true
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: []
-HelpMessage: ''
-```
-
-### -Force
-
-Suppress the confirmation prompt when auto-creating a `prf-encryption` credential.
-Suppress the confirmation prompt when auto-creating a credential.
-Suppress the confirmation prompt when auto-creating a credential.
-Suppress the confirmation prompt when auto-creating a credential.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: ''
-SupportsWildcards: false
-Aliases: []
-ParameterSets:
-- Name: (All)
-  Position: Named
-  IsRequired: false
   ValueFromPipeline: false
   ValueFromPipelineByPropertyName: false
   ValueFromRemainingArguments: false

--- a/Docs/Commands/powershellYK.md
+++ b/Docs/Commands/powershellYK.md
@@ -164,7 +164,7 @@ Create a self signed certificate
 
 ### [Protect-YubiKeyFIDO2File](Protect-YubiKeyFIDO2File.md)
 
-Encrypts a file using FIDO2 PRF (hmac-secret) extension on a YubiKey.
+Encrypts a file using FIDO2 PRF (hmac-secret / hmac-secret-mc) extension on a YubiKey.
 
 ### [Register-YubikeyBIOFingerprint](Register-YubikeyBIOFingerprint.md)
 

--- a/Docs/Commands/powershellYK.md
+++ b/Docs/Commands/powershellYK.md
@@ -164,7 +164,7 @@ Create a self signed certificate
 
 ### [Protect-YubiKeyFIDO2File](Protect-YubiKeyFIDO2File.md)
 
-Encrypts a file using FIDO2 PRF (hmac-secret / hmac-secret-mc) extension on a YubiKey.
+Encrypts a file using FIDO2 PRF (hmac-secret) extension on a YubiKey.
 
 ### [Register-YubikeyBIOFingerprint](Register-YubikeyBIOFingerprint.md)
 

--- a/Module/Cmdlets/FIDO2/NewFIDO2Credential.cs
+++ b/Module/Cmdlets/FIDO2/NewFIDO2Credential.cs
@@ -165,7 +165,7 @@ namespace powershellYK.Cmdlets.Fido
                 }
 
                 // Add HMAC secret extension if supported
-                if (fido2Session.AuthenticatorInfo.IsExtensionSupported("hmac-secret"))
+                if (fido2Session.AuthenticatorInfo.IsExtensionSupported(Extensions.HmacSecret))
                 {
                     make.AddHmacSecretExtension(fido2Session.AuthenticatorInfo);
                 }

--- a/Module/Cmdlets/FIDO2/ProtectYubiKeyFIDO2File.cs
+++ b/Module/Cmdlets/FIDO2/ProtectYubiKeyFIDO2File.cs
@@ -15,7 +15,7 @@
 /// Encrypts secret.txt, automatically creating or reusing a "prf-encryption" credential.
 ///
 /// .EXAMPLE
-/// Protect-YubiKeyFIDO2File -Path .\secret.txt -Force
+/// Protect-YubiKeyFIDO2File -Path .\secret.txt -Confirm:$false
 /// Same as above but skips the credential-creation confirmation prompt.
 ///
 /// .EXAMPLE
@@ -82,9 +82,6 @@ namespace powershellYK.Cmdlets.Fido
         [Alias("RP", "Origin")]
         [ValidateNotNullOrEmpty]
         public string? RelyingPartyID { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Suppress the confirmation prompt when auto-creating a credential.")]
-        public SwitchParameter Force { get; set; }
 
         private const string AutoCreateRpId = "prf-encryption";
         private const string AutoCreateUsername = "prf-encryption";
@@ -175,8 +172,7 @@ namespace powershellYK.Cmdlets.Fido
                 if (credIdBytes is null)
                 {
                     string username = AutoCreateUsername;
-
-                    if (!Force.IsPresent && !ShouldContinue(
+                    if (!ShouldProcess(
                         $"No credential or relying party was provided. A new FIDO2 credential will be created on RP '{rpId}'. Continue?",
                         "Create FIDO2 credential"))
                     {

--- a/Module/Cmdlets/FIDO2/ProtectYubiKeyFIDO2File.cs
+++ b/Module/Cmdlets/FIDO2/ProtectYubiKeyFIDO2File.cs
@@ -4,8 +4,11 @@
 /// Requires a YubiKey with FIDO2 hmac-secret support, a FIDO2 PIN, and administrator
 /// privileges on Windows.
 /// When no credential or relying party is provided, the cmdlet automatically creates a
-/// synthetic FIDO2 credential (RP and username both set to "prf-encryption" and
-/// uses it for encryption.
+/// synthetic FIDO2 credential (RP and username both set to "prf-encryption") and
+/// uses it for encryption. On YubiKey firmware 5.8+ (hmac-secret-mc), first-time
+/// AutoCreate derives the PRF during credential creation so only one touch is required.
+/// Older firmware enables hmac-secret at creation then requests the PRF with a second
+/// assertion. Reuse of an existing credential always uses a single GetAssertions call.
 ///
 /// .EXAMPLE
 /// Protect-YubiKeyFIDO2File -Path .\secret.txt
@@ -39,8 +42,8 @@ using System.Management.Automation;
 using System.Security.Cryptography;
 using Yubico.YubiKey;
 using Yubico.YubiKey.Fido2;
-using Yubico.YubiKey.Cryptography;
 using powershellYK.support;
+using powershellYK.support.FIDO2;
 using powershellYK.support.transform;
 using powershellYK.support.validators;
 using powershellYK.FIDO2;
@@ -144,6 +147,7 @@ namespace powershellYK.Cmdlets.Fido
 
             byte[] credIdBytes;
             string rpId;
+            byte[]? prfOutput = null;
 
             if (ParameterSetName == "AutoCreate")
             {
@@ -179,21 +183,46 @@ namespace powershellYK.Cmdlets.Fido
                         return;
                     }
 
-                    WriteDebug($"AutoCreate: invoking New-YubiKeyFIDO2Credential for RP '{rpId}', user '{username}'...");
-                    var ps = PowerShell.Create(RunspaceMode.CurrentRunspace)
-                        .AddCommand("New-YubiKeyFIDO2Credential")
-                        .AddParameter("RelyingPartyID", rpId)
-                        .AddParameter("Username", username)
-                        .AddParameter("Confirm", false);
-                    if (this.MyInvocation.BoundParameters.ContainsKey("InformationAction"))
-                        ps.AddParameter("InformationAction", this.MyInvocation.BoundParameters["InformationAction"]);
+                    using (var createSession = new Fido2Session((YubiKeyDevice)YubiKeyModule._yubikey!))
+                    {
+                        createSession.KeyCollector = YubiKeyModule._KeyCollector.YKKeyCollectorDelegate;
 
-                    var results = ps.Invoke();
-                    if (results.Count == 0 || results[0].BaseObject is not CredentialData credData)
-                        throw new InvalidOperationException("Failed to create a FIDO2 credential for file encryption.");
+                        if (createSession.AuthenticatorInfo.IsExtensionSupported(Extensions.HmacSecretMc))
+                        {
+                            WriteDebug("AutoCreate: hmac-secret-mc supported (firmware 5.8+); creating credential and deriving PRF in one operation...");
+                            Console.WriteLine("Touch the YubiKey...");
+                            var mcResult = Fido2PrfHelper.TryCreateCredentialWithHmacSecretMc(createSession, rpId, username, salt);
+                            if (mcResult is not null)
+                            {
+                                credIdBytes = mcResult.Value.CredentialId;
+                                prfOutput = mcResult.Value.PrfOutput;
+                                WriteDebug($"AutoCreate: hmac-secret-mc credential created, ID {Convert.ToHexString(credIdBytes).ToLowerInvariant()}, {prfOutput.Length}-byte PRF.");
+                            }
+                        }
+                        else
+                        {
+                            WriteDebug("AutoCreate: hmac-secret-mc not supported on this firmware.");
+                        }
+                    }
 
-                    credIdBytes = credData.CredentialId!.Value.ToArray();
-                    WriteDebug($"AutoCreate: credential created, ID {Convert.ToHexString(credIdBytes).ToLowerInvariant()}");
+                    if (prfOutput is null)
+                    {
+                        WriteDebug($"AutoCreate: falling back to New-YubiKeyFIDO2Credential + assertion for RP '{rpId}', user '{username}'...");
+                        var ps = PowerShell.Create(RunspaceMode.CurrentRunspace)
+                            .AddCommand("New-YubiKeyFIDO2Credential")
+                            .AddParameter("RelyingPartyID", rpId)
+                            .AddParameter("Username", username)
+                            .AddParameter("Confirm", false);
+                        if (this.MyInvocation.BoundParameters.ContainsKey("InformationAction"))
+                            ps.AddParameter("InformationAction", this.MyInvocation.BoundParameters["InformationAction"]);
+
+                        var results = ps.Invoke();
+                        if (results.Count == 0 || results[0].BaseObject is not CredentialData credData)
+                            throw new InvalidOperationException("Failed to create a FIDO2 credential for file encryption.");
+
+                        credIdBytes = credData.CredentialId!.Value.ToArray();
+                        WriteDebug($"AutoCreate: credential created, ID {Convert.ToHexString(credIdBytes).ToLowerInvariant()}");
+                    }
                 }
             }
             else if (ParameterSetName == "WithCredential")
@@ -265,63 +294,57 @@ namespace powershellYK.Cmdlets.Fido
                 rpId = RelyingPartyID!;
             }
 
-            // Fresh session for the assertion -- not contaminated by credential creation
-            using (var fido2Session = new Fido2Session((YubiKeyDevice)YubiKeyModule._yubikey!))
+            if (credIdBytes is null)
             {
-                fido2Session.KeyCollector = YubiKeyModule._KeyCollector.YKKeyCollectorDelegate;
-
-                // Build client data hash for the assertion
-                var relyingParty = new RelyingParty(rpId);
-                var clientData = new { type = "webauthn.get", origin = $"https://{rpId}", challenge = Convert.ToBase64String(salt) };
-                var clientDataJSON = System.Text.Json.JsonSerializer.Serialize(clientData);
-                var clientDataBytes = System.Text.Encoding.UTF8.GetBytes(clientDataJSON);
-                var digester = CryptographyProviders.Sha256Creator();
-                _ = digester.TransformFinalBlock(clientDataBytes, 0, clientDataBytes.Length);
-
-                // Request assertion with hmac-secret extension to get PRF output
-                var getParams = new GetAssertionParameters(relyingParty, digester.Hash!);
-                getParams.RequestHmacSecretExtension(salt);
-                getParams.AllowCredential(new CredentialID(credIdBytes).ToYubicoFIDO2CredentialID());
-
-                WriteDebug("Requesting assertion with hmac-secret extension...");
-                Console.WriteLine("Touch the YubiKey...");
-                IReadOnlyList<GetAssertionData> assertions = fido2Session.GetAssertions(getParams);
-
-                byte[] prfOutput = assertions[0].AuthenticatorData.GetHmacSecretExtension(fido2Session.AuthProtocol);
-                WriteDebug($"Received {prfOutput.Length}-byte PRF output from YubiKey.");
-
-                // Derive AES-256 key using HKDF-SHA256 with domain separation
-                byte[] derivedKey = HKDF.DeriveKey(
-                    HashAlgorithmName.SHA256,
-                    ikm: prfOutput,
-                    outputLength: 32,
-                    salt: null,
-                    info: HkdfInfo);
-
-                // Encrypt plaintext with AES-256-GCM
-                byte[] iv = RandomNumberGenerator.GetBytes(PRFEncryptedFile.IVLength);
-                byte[] ciphertext = new byte[plaintext.Length];
-                byte[] tag = new byte[PRFEncryptedFile.TagLength];
-
-                using (var aes = new AesGcm(derivedKey, tagSizeInBytes: PRFEncryptedFile.TagLength))
-                {
-                    aes.Encrypt(iv, plaintext, ciphertext, tag);
-                }
-
-                // Write encrypted file with structured header
-                var encryptedFile = new PRFEncryptedFile(credIdBytes, rpId, salt, iv, tag, ciphertext);
-                try
-                {
-                    File.WriteAllBytes(resolvedOutputPath, encryptedFile.Serialize());
-                }
-                catch (Exception ex)
-                {
-                    throw new IOException($"Failed to write encrypted file to '{resolvedOutputPath}'.", ex);
-                }
-
-                WriteInformation(new InformationRecord($"Encrypted file written to {resolvedOutputPath}", "Protect-YubiKeyFIDO2File"));
-                WriteObject(new FileInfo(resolvedOutputPath));
+                throw new InvalidOperationException("Failed to resolve a FIDO2 credential for file encryption.");
             }
+
+            // hmac-secret-mc already returned the PRF during MakeCredential; otherwise request it via GetAssertions
+            if (prfOutput is null)
+            {
+                using (var fido2Session = new Fido2Session((YubiKeyDevice)YubiKeyModule._yubikey!))
+                {
+                    fido2Session.KeyCollector = YubiKeyModule._KeyCollector.YKKeyCollectorDelegate;
+
+                    WriteDebug("Requesting assertion with hmac-secret extension...");
+                    Console.WriteLine("Touch the YubiKey...");
+                    prfOutput = Fido2PrfHelper.GetPrfViaAssertion(fido2Session, rpId, credIdBytes, salt);
+                }
+            }
+
+            WriteDebug($"Received {prfOutput.Length}-byte PRF output from YubiKey.");
+
+            // Derive AES-256 key using HKDF-SHA256 with domain separation
+            byte[] derivedKey = HKDF.DeriveKey(
+                HashAlgorithmName.SHA256,
+                ikm: prfOutput,
+                outputLength: 32,
+                salt: null,
+                info: HkdfInfo);
+
+            // Encrypt plaintext with AES-256-GCM
+            byte[] iv = RandomNumberGenerator.GetBytes(PRFEncryptedFile.IVLength);
+            byte[] ciphertext = new byte[plaintext.Length];
+            byte[] tag = new byte[PRFEncryptedFile.TagLength];
+
+            using (var aes = new AesGcm(derivedKey, tagSizeInBytes: PRFEncryptedFile.TagLength))
+            {
+                aes.Encrypt(iv, plaintext, ciphertext, tag);
+            }
+
+            // Write encrypted file with structured header
+            var encryptedFile = new PRFEncryptedFile(credIdBytes, rpId, salt, iv, tag, ciphertext);
+            try
+            {
+                File.WriteAllBytes(resolvedOutputPath, encryptedFile.Serialize());
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Failed to write encrypted file to '{resolvedOutputPath}'.", ex);
+            }
+
+            WriteInformation(new InformationRecord($"Encrypted file written to {resolvedOutputPath}", "Protect-YubiKeyFIDO2File"));
+            WriteObject(new FileInfo(resolvedOutputPath));
         }
     }
 }

--- a/Module/support/FIDO2/Fido2PrfHelper.cs
+++ b/Module/support/FIDO2/Fido2PrfHelper.cs
@@ -1,0 +1,94 @@
+/// <summary>
+/// Helpers for FIDO2 PRF (hmac-secret / hmac-secret-mc) used by file encryption.
+/// hmac-secret-mc (firmware 5.8+) returns the PRF during MakeCredential so first-time
+/// encryption needs only one user interaction. Older firmware falls back to hmac-secret
+/// via GetAssertions.
+///
+/// .EXAMPLE
+/// var result = Fido2PrfHelper.TryCreateCredentialWithHmacSecretMc(session, "prf-encryption", "prf-encryption", salt);
+/// if (result is not null) { credId = result.Value.CredentialId; prf = result.Value.PrfOutput; }
+///
+/// .EXAMPLE
+/// byte[] prf = Fido2PrfHelper.GetPrfViaAssertion(session, rpId, credId, salt);
+/// </summary>
+
+// Imports
+using System.Text;
+using System.Text.Json;
+using Yubico.YubiKey.Cryptography;
+using Yubico.YubiKey.Fido2;
+using Yubico.YubiKey.Fido2.Cose;
+using powershellYK.FIDO2;
+
+namespace powershellYK.support.FIDO2
+{
+    // Helpers for FIDO2 PRF derivation via hmac-secret and hmac-secret-mc
+    public static class Fido2PrfHelper
+    {
+        // Creates a discoverable credential and returns the PRF in one MakeCredential when hmac-secret-mc is supported (firmware 5.8+). Returns null when the extension is not supported so callers can fall back to hmac-secret + GetAssertions.
+        public static (byte[] CredentialId, byte[] PrfOutput)? TryCreateCredentialWithHmacSecretMc(
+            Fido2Session fido2Session,
+            string relyingPartyId,
+            string username,
+            ReadOnlyMemory<byte> salt)
+        {
+            if (!fido2Session.AuthenticatorInfo.IsExtensionSupported(Extensions.HmacSecretMc))
+            {
+                return null;
+            }
+
+            var relyingParty = new RelyingParty(relyingPartyId) { Name = relyingPartyId };
+            byte[] userId = SyntheticCredentialHelper.GenerateUserID();
+            var userEntity = new UserEntity(userId.AsMemory())
+            {
+                Name = username,
+                DisplayName = username,
+            };
+
+            var make = new MakeCredentialParameters(relyingParty, userEntity);
+            make.AddOption("rk", true);
+            make.AddHmacSecretMcExtension(fido2Session.AuthenticatorInfo, salt);
+            make.AddAlgorithm("public-key", CoseAlgorithmIdentifier.ES256);
+
+            var challenge = Challenge.CreateSyntheticChallenge(relyingPartyId);
+            var clientData = new
+            {
+                type = "webauthn.create",
+                origin = $"https://{relyingParty.Id}",
+                challenge = challenge.Base64URLEncode(),
+            };
+            var clientDataJSON = JsonSerializer.Serialize(clientData);
+            var clientDataBytes = Encoding.UTF8.GetBytes(clientDataJSON);
+            var digester = CryptographyProviders.Sha256Creator();
+            _ = digester.TransformFinalBlock(clientDataBytes, 0, clientDataBytes.Length);
+            make.ClientDataHash = digester.Hash!.AsMemory();
+
+            MakeCredentialData credentialData = fido2Session.MakeCredential(make);
+            byte[] prfOutput = credentialData.AuthenticatorData.GetHmacSecretExtension(fido2Session.AuthProtocol);
+            byte[] credId = credentialData.AuthenticatorData.CredentialId!.Id.ToArray();
+            return (credId, prfOutput);
+        }
+
+        // Requests an assertion with hmac-secret and returns the decrypted 32-byte PRF for the given credential and salt.
+        public static byte[] GetPrfViaAssertion(
+            Fido2Session fido2Session,
+            string relyingPartyId,
+            byte[] credentialId,
+            ReadOnlyMemory<byte> salt)
+        {
+            var relyingParty = new RelyingParty(relyingPartyId);
+            var clientData = new { type = "webauthn.get", origin = $"https://{relyingPartyId}", challenge = Convert.ToBase64String(salt.ToArray()) };
+            var clientDataJSON = JsonSerializer.Serialize(clientData);
+            var clientDataBytes = Encoding.UTF8.GetBytes(clientDataJSON);
+            var digester = CryptographyProviders.Sha256Creator();
+            _ = digester.TransformFinalBlock(clientDataBytes, 0, clientDataBytes.Length);
+
+            var getParams = new GetAssertionParameters(relyingParty, digester.Hash!);
+            getParams.RequestHmacSecretExtension(salt);
+            getParams.AllowCredential(new CredentialID(credentialId).ToYubicoFIDO2CredentialID());
+
+            IReadOnlyList<GetAssertionData> assertions = fido2Session.GetAssertions(getParams);
+            return assertions[0].AuthenticatorData.GetHmacSecretExtension(fido2Session.AuthProtocol);
+        }
+    }
+}

--- a/Pester/340-FIDO2prf.tests.ps1
+++ b/Pester/340-FIDO2prf.tests.ps1
@@ -66,7 +66,7 @@ Describe "FIDO2 PRF AutoCreate Tests" -Tag @("FIDO2",'FIDO2prf')  {
     }
 
     It -Name "AutoCreate encrypts without -Credential (hmac-secret-mc on 5.8+, two-step hmac-secret otherwise)" -Test {
-        { Protect-YubiKeyFIDO2File -Path $autoTextIn -OutFile $autoEncrypted -Force -Confirm:$False } | Should -Not -Throw
+        { Protect-YubiKeyFIDO2File -Path $autoTextIn -OutFile $autoEncrypted -Confirm:$False } | Should -Not -Throw
         (Test-Path $autoEncrypted) | Should -BeTrue
     }
 
@@ -77,7 +77,7 @@ Describe "FIDO2 PRF AutoCreate Tests" -Tag @("FIDO2",'FIDO2prf')  {
     }
 
     It -Name "Second AutoCreate Protect reuses the prf-encryption credential" -Test {
-        { Protect-YubiKeyFIDO2File -Path $autoTextIn -OutFile $autoEncryptedReuse -Force -Confirm:$False } | Should -Not -Throw
+        { Protect-YubiKeyFIDO2File -Path $autoTextIn -OutFile $autoEncryptedReuse -Confirm:$False } | Should -Not -Throw
         (Test-Path $autoEncryptedReuse) | Should -BeTrue
         $reuseOut = [System.IO.Path]::GetTempFileName()
         if (Test-Path $reuseOut) { Remove-Item $reuseOut }

--- a/Pester/340-FIDO2prf.tests.ps1
+++ b/Pester/340-FIDO2prf.tests.ps1
@@ -1,4 +1,4 @@
-Describe "FIDO2 Blob Tests" -Tag @("FIDO2",'FIDO2prf')  {
+Describe "FIDO2 PRF Tests" -Tag @("FIDO2",'FIDO2prf')  {
     BeforeAll {
         { Connect-YubiKey } | Should -Not -Throw
         { Connect-YubiKeyFIDO2 -PIN (ConvertTo-SecureString -String '123456' -AsPlainText -Force) } | Should -Not -Throw
@@ -36,5 +36,57 @@ Describe "FIDO2 Blob Tests" -Tag @("FIDO2",'FIDO2prf')  {
         { Unprotect-YubiKeyFIDO2File -Path $encrypted -OutFile $textout -Confirm:$False} | Should -Not -Throw
         (Test-Path $textout) | Should -BeTrue
         (Get-Content -Path $textout) | Should -Be "Plaintext unencrypted file"
+    }
+}
+
+Describe "FIDO2 PRF AutoCreate Tests" -Tag @("FIDO2",'FIDO2prf')  {
+    BeforeAll {
+        { Connect-YubiKey } | Should -Not -Throw
+        { Connect-YubiKeyFIDO2 -PIN (ConvertTo-SecureString -String '123456' -AsPlainText -Force) } | Should -Not -Throw
+        Get-YubiKeyFIDO2Credential | Where-Object { $_.RPId -eq 'prf-encryption' } | ForEach-Object {
+            Remove-YubikeyFIDO2Credential -CredentialId $_.CredentialID -Confirm:$false
+        }
+        $autoTextIn = [System.IO.Path]::GetTempFileName()
+        Set-Content -Value "AutoCreate plaintext" -Path $autoTextIn
+        $autoEncrypted = [System.IO.Path]::GetTempFileName()
+        $autoEncryptedReuse = [System.IO.Path]::GetTempFileName()
+        $autoTextOut = [System.IO.Path]::GetTempFileName()
+        if (Test-Path $autoTextOut) { Remove-Item $autoTextOut }
+        if (Test-Path $autoEncrypted) { Remove-Item $autoEncrypted }
+        if (Test-Path $autoEncryptedReuse) { Remove-Item $autoEncryptedReuse }
+    }
+    AfterAll {
+        Get-YubiKeyFIDO2Credential | Where-Object { $_.RPId -eq 'prf-encryption' } | ForEach-Object {
+            Remove-YubikeyFIDO2Credential -CredentialId $_.CredentialID -Confirm:$false
+        }
+        if (Test-Path $autoTextIn) { Remove-Item $autoTextIn }
+        if (Test-Path $autoEncrypted) { Remove-Item $autoEncrypted }
+        if (Test-Path $autoEncryptedReuse) { Remove-Item $autoEncryptedReuse }
+        if (Test-Path $autoTextOut) { Remove-Item $autoTextOut }
+    }
+
+    It -Name "AutoCreate encrypts without -Credential (hmac-secret-mc on 5.8+, two-step hmac-secret otherwise)" -Test {
+        { Protect-YubiKeyFIDO2File -Path $autoTextIn -OutFile $autoEncrypted -Force -Confirm:$False } | Should -Not -Throw
+        (Test-Path $autoEncrypted) | Should -BeTrue
+    }
+
+    It -Name "Unprotect AutoCreate-encrypted file" -Test {
+        { Unprotect-YubiKeyFIDO2File -Path $autoEncrypted -OutFile $autoTextOut -Confirm:$False } | Should -Not -Throw
+        (Test-Path $autoTextOut) | Should -BeTrue
+        (Get-Content -Path $autoTextOut) | Should -Be "AutoCreate plaintext"
+    }
+
+    It -Name "Second AutoCreate Protect reuses the prf-encryption credential" -Test {
+        { Protect-YubiKeyFIDO2File -Path $autoTextIn -OutFile $autoEncryptedReuse -Force -Confirm:$False } | Should -Not -Throw
+        (Test-Path $autoEncryptedReuse) | Should -BeTrue
+        $reuseOut = [System.IO.Path]::GetTempFileName()
+        if (Test-Path $reuseOut) { Remove-Item $reuseOut }
+        try {
+            { Unprotect-YubiKeyFIDO2File -Path $autoEncryptedReuse -OutFile $reuseOut -Confirm:$False } | Should -Not -Throw
+            (Get-Content -Path $reuseOut) | Should -Be "AutoCreate plaintext"
+        }
+        finally {
+            if (Test-Path $reuseOut) { Remove-Item $reuseOut }
+        }
     }
 }

--- a/Pester/340-FIDO2prf.tests.ps1
+++ b/Pester/340-FIDO2prf.tests.ps1
@@ -1,8 +1,8 @@
 Describe "FIDO2 PRF Tests" -Tag @("FIDO2",'FIDO2prf')  {
     BeforeAll {
-        { Connect-YubiKey } | Should -Not -Throw
-        { Connect-YubiKeyFIDO2 -PIN (ConvertTo-SecureString -String '123456' -AsPlainText -Force) } | Should -Not -Throw
-        { New-YubiKeyFIDO2Credential -RelyingPartyID 'powershellYK-FIDO2-prf' -Challenge ([powershellYK.FIDO2.Challenge]::FakeChallange("powershellYK")) -Discoverable:$true -Username 'powershellYKUser' -UserID 0x01 } | Should -Not -Throw
+        Connect-YubiKey
+        Connect-YubiKeyFIDO2 -PIN (ConvertTo-SecureString -String '123456' -AsPlainText -Force)
+        New-YubiKeyFIDO2Credential -RelyingPartyID 'powershellYK-FIDO2-prf' -Challenge ([powershellYK.FIDO2.Challenge]::FakeChallange("powershellYK")) -Discoverable:$true -Username 'powershellYKUser' -UserID 0x01
         $textin = [System.IO.Path]::GetTempFileName()
         Set-Content -Value "Plaintext unencrypted file" -Path $textin
         $encrypted = [System.IO.Path]::GetTempFileName()
@@ -21,7 +21,7 @@ Describe "FIDO2 PRF Tests" -Tag @("FIDO2",'FIDO2prf')  {
 
     It -Name "Encrypt file with FIDO2 prf with specified outfile" -Test {
         $cred = Get-YubiKeyFIDO2Credential | Where-Object { $_.RelyingParty.Id -eq "powershellYK-FIDO2-prf" }
-        { Protect-YubiKeyFIDO2File -Path $textin -Credential $cred -OutFile $encrypted -Confirm:$False} | Should -Not -Throw
+        Protect-YubiKeyFIDO2File -Path $textin -Credential $cred -OutFile $encrypted -Confirm:$False
         (Test-Path $encrypted) | Should -BeTrue
     }
 
@@ -41,8 +41,8 @@ Describe "FIDO2 PRF Tests" -Tag @("FIDO2",'FIDO2prf')  {
 
 Describe "FIDO2 PRF AutoCreate Tests" -Tag @("FIDO2",'FIDO2prf')  {
     BeforeAll {
-        { Connect-YubiKey } | Should -Not -Throw
-        { Connect-YubiKeyFIDO2 -PIN (ConvertTo-SecureString -String '123456' -AsPlainText -Force) } | Should -Not -Throw
+        Connect-YubiKey
+        Connect-YubiKeyFIDO2 -PIN (ConvertTo-SecureString -String '123456' -AsPlainText -Force)
         Get-YubiKeyFIDO2Credential | Where-Object { $_.RPId -eq 'prf-encryption' } | ForEach-Object {
             Remove-YubikeyFIDO2Credential -CredentialId $_.CredentialID -Confirm:$false
         }


### PR DESCRIPTION
Use `hmac-secret-mc` (over `hmac-secret` in earlier firmware) for _one_-touch credential creation and encryption on firmware `5.8`+.
Falls back to MakeCredential + GetAssertions on older YubiKey firmware (two-touch required).